### PR TITLE
Fix scoreboard objective creation

### DIFF
--- a/src/main/java/net/kettlemc/kessentials/util/ScoreboardHandler.java
+++ b/src/main/java/net/kettlemc/kessentials/util/ScoreboardHandler.java
@@ -42,7 +42,8 @@ public class ScoreboardHandler implements Listener {
             String clan = clanDAO.getClan(player.getUniqueId());
 
             Scoreboard board = manager.getNewScoreboard();
-            Objective obj = board.registerNewObjective("stats", "dummy", ChatColor.GREEN + "Stats");
+            Objective obj = board.registerNewObjective("stats", "dummy");
+            obj.setDisplayName(ChatColor.GREEN + "Stats");
             obj.setDisplaySlot(DisplaySlot.SIDEBAR);
 
             Score killScore = obj.getScore(ChatColor.YELLOW + "Kills: ");


### PR DESCRIPTION
## Summary
- update scoreboard objective to set display name separately

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68421074219c8331a91b69d7c1aef368