### PR TITLE
Use OptionMapping for slash options

### DIFF
--- a/src/main/java/net/kettlemc/kessentials/discord/command/commands/AdminInfoSlashCommand.java
+++ b/src/main/java/net/kettlemc/kessentials/discord/command/commands/AdminInfoSlashCommand.java
@@ -4,6 +4,7 @@ import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
@@ -30,7 +31,8 @@ public class AdminInfoSlashCommand extends SlashCommand {
             event.reply("You do not have permission to use this command.").setEphemeral(true).queue();
             return;
         }
-        String name = event.getOption("name", String.class);
+        OptionMapping nameOption = event.getOption("name");
+        String name = nameOption != null ? nameOption.getAsString() : null;
         if (name == null || name.isEmpty()) {
             event.reply("Please provide a player name.").setEphemeral(true).queue();
             return;

--- a/src/main/java/net/kettlemc/kessentials/discord/command/commands/PlayerInfoSlashCommand.java
+++ b/src/main/java/net/kettlemc/kessentials/discord/command/commands/PlayerInfoSlashCommand.java
@@ -3,6 +3,7 @@ package net.kettlemc.kessentials.discord.command.commands;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
@@ -24,7 +25,8 @@ public class PlayerInfoSlashCommand extends SlashCommand {
 
     @Override
     public void onExecute(SlashCommandInteractionEvent event, Member member, MessageChannel channel) {
-        String name = event.getOption("name", String.class);
+        OptionMapping nameOption = event.getOption("name");
+        String name = nameOption != null ? nameOption.getAsString() : null;
         if (name == null || name.isEmpty()) {
             event.reply("Please provide a player name.").setEphemeral(true).queue();
             return;

--- a/src/main/java/net/kettlemc/kessentials/discord/command/commands/PositionSlashCommand.java
+++ b/src/main/java/net/kettlemc/kessentials/discord/command/commands/PositionSlashCommand.java
@@ -4,6 +4,7 @@ import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
@@ -27,7 +28,8 @@ public class PositionSlashCommand extends SlashCommand {
             event.reply("You do not have permission to use this command.").setEphemeral(true).queue();
             return;
         }
-        String name = event.getOption("name", String.class);
+        OptionMapping nameOption = event.getOption("name");
+        String name = nameOption != null ? nameOption.getAsString() : null;
         if (name == null || name.isEmpty()) {
             event.reply("Please provide a player name.").setEphemeral(true).queue();
             return;

--- a/src/main/java/net/kettlemc/kessentials/discord/command/commands/TeamInfoSlashCommand.java
+++ b/src/main/java/net/kettlemc/kessentials/discord/command/commands/TeamInfoSlashCommand.java
@@ -3,6 +3,7 @@ package net.kettlemc.kessentials.discord.command.commands;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
@@ -27,7 +28,8 @@ public class TeamInfoSlashCommand extends SlashCommand {
 
     @Override
     public void onExecute(SlashCommandInteractionEvent event, Member member, MessageChannel channel) {
-        String name = event.getOption("name", String.class);
+        OptionMapping nameOption = event.getOption("name");
+        String name = nameOption != null ? nameOption.getAsString() : null;
         if (name == null || name.isEmpty()) {
             event.reply("Please provide a clan name.").setEphemeral(true).queue();
             return;

--- a/src/main/java/net/kettlemc/kessentials/discord/command/commands/VerifySlashCommand.java
+++ b/src/main/java/net/kettlemc/kessentials/discord/command/commands/VerifySlashCommand.java
@@ -3,6 +3,7 @@ package net.kettlemc.kessentials.discord.command.commands;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
@@ -24,7 +25,8 @@ public class VerifySlashCommand extends SlashCommand {
 
     @Override
     public void onExecute(SlashCommandInteractionEvent event, Member member, MessageChannel channel) {
-        String code = event.getOption("code", String.class);
+        OptionMapping codeOption = event.getOption("code");
+        String code = codeOption != null ? codeOption.getAsString() : null;
         if (code == null || code.isEmpty()) {
             event.reply("Please provide your verification code.").setEphemeral(true).queue();
             return;


### PR DESCRIPTION
## Summary
- retrieve `name` and `code` slash command options using `OptionMapping`

## Testing
- `./gradlew build` *(fails: unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68420f7790508331859f5d80dc8157cc