### PR TITLE
Fix sendMessage call signature

### DIFF
--- a/src/main/java/net/kettlemc/kessentials/command/home/HomeCommand.java
+++ b/src/main/java/net/kettlemc/kessentials/command/home/HomeCommand.java
@@ -37,7 +37,8 @@ public class HomeCommand implements CommandExecutor, TabCompleter {
         if (args[0].equalsIgnoreCase("list")) {
             Essentials.instance().messages().sendMessage(player, Messages.HOME_LIST_HEADER);
             Essentials.instance().homeHandler().getHomes(player.getUniqueId()).forEach(
-                    home -> Essentials.instance().messages().sendMessage(player, Messages.HOME_LIST_ENTRY, true, Messages.HOME_LIST_HOVER, "/home " + home.name(), Placeholder.of("name", (ctx, argument) -> home.name()))
+                    home -> Essentials.instance().messages().sendMessage(player, Messages.HOME_LIST_ENTRY,
+                            Placeholder.of("name", (ctx, argument) -> home.name()))
             );
             return true;
         }

--- a/src/main/java/net/kettlemc/kessentials/command/tpa/TPACommand.java
+++ b/src/main/java/net/kettlemc/kessentials/command/tpa/TPACommand.java
@@ -29,10 +29,14 @@ public class TPACommand implements CommandExecutor, TabCompleter {
         }
 
         if (TeleportRequest.request(requester, target)) {
-            Essentials.instance().messages().sendMessage(requester, Messages.TPA_REQUEST_SENT, Placeholder.of("target", (ctx, args) -> target.getName()));
-            Essentials.instance().messages().sendMessage(target, Messages.TPA_REQUEST_RECEIVED, Placeholder.of("requester", (ctx, args) -> requester.getName()));
-            Essentials.instance().messages().sendMessage(target, Messages.TPA_REQUEST_ACCEPT, true, Messages.TPA_REQUEST_ACCEPT_HOVER, "/tpaccept " + requester.getName(), Placeholder.of("requester", (ctx, args) -> requester.getName()));
-            Essentials.instance().messages().sendMessage(target, Messages.TPA_REQUEST_DENY, true, Messages.TPA_REQUEST_DENY_HOVER, "/tpdeny " + requester.getName(), Placeholder.of("requester", (ctx, args) -> requester.getName()));
+            Essentials.instance().messages().sendMessage(requester, Messages.TPA_REQUEST_SENT,
+                    Placeholder.of("target", (ctx, args) -> target.getName()));
+            Essentials.instance().messages().sendMessage(target, Messages.TPA_REQUEST_RECEIVED,
+                    Placeholder.of("requester", (ctx, args) -> requester.getName()));
+            Essentials.instance().messages().sendMessage(target, Messages.TPA_REQUEST_ACCEPT,
+                    Placeholder.of("requester", (ctx, args) -> requester.getName()));
+            Essentials.instance().messages().sendMessage(target, Messages.TPA_REQUEST_DENY,
+                    Placeholder.of("requester", (ctx, args) -> requester.getName()));
 
         } else {
             Essentials.instance().messages().sendMessage(requester, Messages.TPA_REQUEST_ALREADY_SENT, Placeholder.of("target", (ctx, args) -> target.getName()));

--- a/src/main/java/net/kettlemc/kessentials/command/warp/WarpCommand.java
+++ b/src/main/java/net/kettlemc/kessentials/command/warp/WarpCommand.java
@@ -37,7 +37,8 @@ public class WarpCommand implements CommandExecutor, TabCompleter {
         if (args[0].equalsIgnoreCase("list")) {
             Essentials.instance().messages().sendMessage(player, Messages.WARP_LIST_HEADER);
             Essentials.instance().warpHandler().getWarps().forEach(
-                    warp -> Essentials.instance().messages().sendMessage(player, Messages.WARP_LIST_ENTRY, true, Messages.WARP_LIST_HOVER, "/warp " + warp.name(), Placeholder.of("name", (ctx, argument) -> warp.name()))
+                    warp -> Essentials.instance().messages().sendMessage(player, Messages.WARP_LIST_ENTRY,
+                            Placeholder.of("name", (ctx, argument) -> warp.name()))
             );
             return true;
         }


### PR DESCRIPTION
## Summary
- update HomeCommand to use existing MessageManager API
- update TPACommand to remove unsupported hover message arguments
- update WarpCommand to use standard sendMessage overload

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684217a01a988331b89d1dbbc7a4276d