### PR TITLE
Remove kCommon dependency and add local utils

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -133,11 +133,6 @@ if (klanguageVersion) {
     }
 }
 
-if (kcommonVersion) {
-    dependencies {
-        implementation "net.kettlemc:kcommon:${kcommonVersion}"
-    }
-}
 
 // Use repositories from "repositories.gradle"
 if (file("repositories.gradle").exists()) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ klanguageImplementation =
 # kCommon settings (https://github.com/KettleMC-Network/kCommon)
 # If you want to use kCommon, insert the version here.
 # If you don't want to use kCommon, leave the version empty.
-kcommonVersion = 1.6.0
+kcommonVersion =
 
 # Libby settings (https://github.com/AlessioDP/libby)
 # If you want to use Libby, set this to true.

--- a/src/main/java/net/kettlemc/kessentials/Essentials.java
+++ b/src/main/java/net/kettlemc/kessentials/Essentials.java
@@ -1,6 +1,6 @@
 package net.kettlemc.kessentials;
 
-import net.kettlemc.kcommon.bukkit.ContentManager;
+import net.kettlemc.kessentials.content.ContentManager;
 import net.kettlemc.kessentials.util.MessageManager;
 import net.kettlemc.kessentials.command.*;
 import net.kettlemc.kessentials.command.gui.EnchantingTableCommand;

--- a/src/main/java/net/kettlemc/kessentials/command/GamemodeCommand.java
+++ b/src/main/java/net/kettlemc/kessentials/command/GamemodeCommand.java
@@ -1,7 +1,7 @@
 package net.kettlemc.kessentials.command;
 
 import io.github.almightysatan.slams.Placeholder;
-import net.kettlemc.kcommon.java.NumberUtil;
+import net.kettlemc.kessentials.util.BukkitUtil;
 import net.kettlemc.kessentials.Essentials;
 import net.kettlemc.kessentials.config.Messages;
 import org.bukkit.Bukkit;
@@ -89,7 +89,7 @@ public class GamemodeCommand implements CommandExecutor, TabCompleter {
         try {
             return GameMode.valueOf(gm.toUpperCase());
         } catch (Exception e) {
-            return NumberUtil.isInteger(gm) ? GameMode.getByValue(Integer.parseInt(gm)) : null;
+            return BukkitUtil.isInteger(gm) ? GameMode.getByValue(Integer.parseInt(gm)) : null;
         }
     }
 

--- a/src/main/java/net/kettlemc/kessentials/command/SpeedCommand.java
+++ b/src/main/java/net/kettlemc/kessentials/command/SpeedCommand.java
@@ -1,7 +1,7 @@
 package net.kettlemc.kessentials.command;
 
 import io.github.almightysatan.slams.Placeholder;
-import net.kettlemc.kcommon.java.NumberUtil;
+import net.kettlemc.kessentials.util.BukkitUtil;
 import net.kettlemc.kessentials.Essentials;
 import net.kettlemc.kessentials.config.Messages;
 import org.bukkit.Bukkit;
@@ -56,7 +56,7 @@ public class SpeedCommand implements CommandExecutor, TabCompleter {
     }
 
     private void speed(CommandSender sender, Player target, String arg) {
-        if (!NumberUtil.isInteger(arg)) {
+        if (!BukkitUtil.isInteger(arg)) {
             Essentials.instance().messages().sendMessage(sender, Messages.SPEED_USAGE);
             return;
         }

--- a/src/main/java/net/kettlemc/kessentials/command/gui/EnchantingTableCommand.java
+++ b/src/main/java/net/kettlemc/kessentials/command/gui/EnchantingTableCommand.java
@@ -1,6 +1,6 @@
 package net.kettlemc.kessentials.command.gui;
 
-import net.kettlemc.kcommon.java.NumberUtil;
+import net.kettlemc.kessentials.util.BukkitUtil;
 import net.kettlemc.kessentials.Essentials;
 import net.kettlemc.kessentials.config.Messages;
 import org.bukkit.Bukkit;
@@ -34,7 +34,7 @@ public class EnchantingTableCommand implements CommandExecutor, TabCompleter {
 
             Player player = (Player) sender;
 
-            if (NumberUtil.isInteger(args[0]) && NumberUtil.isInteger(args[1]) && NumberUtil.isInteger(args[2])) {
+            if (BukkitUtil.isInteger(args[0]) && BukkitUtil.isInteger(args[1]) && BukkitUtil.isInteger(args[2])) {
                 int level1 = Integer.parseInt(args[0]);
                 int level2 = Integer.parseInt(args[1]);
                 int level3 = Integer.parseInt(args[2]);
@@ -58,7 +58,7 @@ public class EnchantingTableCommand implements CommandExecutor, TabCompleter {
                 return true;
             }
 
-            if (NumberUtil.isInteger(args[1]) && NumberUtil.isInteger(args[2]) && NumberUtil.isInteger(args[3])) {
+            if (BukkitUtil.isInteger(args[1]) && BukkitUtil.isInteger(args[2]) && BukkitUtil.isInteger(args[3])) {
                 int level1 = Integer.parseInt(args[1]);
                 int level2 = Integer.parseInt(args[2]);
                 int level3 = Integer.parseInt(args[3]);

--- a/src/main/java/net/kettlemc/kessentials/command/home/SetHomeCommand.java
+++ b/src/main/java/net/kettlemc/kessentials/command/home/SetHomeCommand.java
@@ -1,7 +1,7 @@
 package net.kettlemc.kessentials.command.home;
 
 import io.github.almightysatan.slams.Placeholder;
-import net.kettlemc.kcommon.bukkit.BukkitUtil;
+import net.kettlemc.kessentials.util.BukkitUtil;
 import net.kettlemc.kessentials.Essentials;
 import net.kettlemc.kessentials.config.Configuration;
 import net.kettlemc.kessentials.config.Messages;

--- a/src/main/java/net/kettlemc/kessentials/config/Messages.java
+++ b/src/main/java/net/kettlemc/kessentials/config/Messages.java
@@ -3,7 +3,7 @@ package net.kettlemc.kessentials.config;
 import io.github.almightysatan.slams.Slams;
 import io.github.almightysatan.slams.minimessage.AdventureMessage;
 import io.github.almightysatan.slams.parser.JacksonParser;
-import net.kettlemc.kcommon.java.FileUtil;
+import net.kettlemc.kessentials.util.BukkitUtil;
 
 import java.io.File;
 import java.io.IOException;
@@ -193,8 +193,8 @@ public class Messages {
 
     public static boolean load() {
         try {
-            FileUtil.saveResourceAsFile(Messages.class, "lang/de.json", LANGUAGE_PATH.resolve("de.json"));
-            FileUtil.saveResourceAsFile(Messages.class, "lang/en.json", LANGUAGE_PATH.resolve("en.json"));
+            BukkitUtil.saveResource(Messages.class, "lang/de.json", LANGUAGE_PATH.resolve("de.json"));
+            BukkitUtil.saveResource(Messages.class, "lang/en.json", LANGUAGE_PATH.resolve("en.json"));
             loadFromFilesInDirectory(LANGUAGE_PATH.toFile());
             return true;
         } catch (IOException | URISyntaxException e) {

--- a/src/main/java/net/kettlemc/kessentials/content/ContentManager.java
+++ b/src/main/java/net/kettlemc/kessentials/content/ContentManager.java
@@ -1,0 +1,34 @@
+package net.kettlemc.kessentials.content;
+
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.event.Listener;
+import org.bukkit.plugin.Plugin;
+
+/**
+ * Simple helper for registering commands and listeners.
+ */
+public class ContentManager {
+
+    private final Plugin plugin;
+
+    public ContentManager(Plugin plugin) {
+        this.plugin = plugin;
+    }
+
+    public void registerCommand(String name, CommandExecutor executor) {
+        var command = plugin.getCommand(name);
+        if (command == null) {
+            plugin.getLogger().warning("Command '" + name + "' is not defined in plugin.yml");
+            return;
+        }
+        command.setExecutor(executor);
+        if (executor instanceof TabCompleter) {
+            command.setTabCompleter((TabCompleter) executor);
+        }
+    }
+
+    public void registerListener(Listener listener) {
+        plugin.getServer().getPluginManager().registerEvents(listener, plugin);
+    }
+}

--- a/src/main/java/net/kettlemc/kessentials/discord/listener/MessageListener.java
+++ b/src/main/java/net/kettlemc/kessentials/discord/listener/MessageListener.java
@@ -5,7 +5,7 @@ import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.entities.channel.ChannelType;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
-import net.kettlemc.kcommon.java.StringUtil;
+import net.kettlemc.kessentials.util.BukkitUtil;
 import net.kettlemc.kessentials.Essentials;
 import net.kettlemc.kessentials.config.DiscordConfiguration;
 import net.kettlemc.kessentials.config.Messages;
@@ -28,7 +28,7 @@ public class MessageListener extends ListenerAdapter {
             roles = event.getMember().getRoles();
         }
 
-        String rank = roles.isEmpty() ? DiscordConfiguration.DEFAULT_RANK.getValue() : StringUtil.stripEmojis(roles.get(0).getName()).trim();
+        String rank = roles.isEmpty() ? DiscordConfiguration.DEFAULT_RANK.getValue() : BukkitUtil.stripEmojis(roles.get(0).getName()).trim();
 
         Essentials.instance().messages().broadcastMessage(Messages.DISCORD_CHAT_FORMAT_MINECRAFT,
                 false,

--- a/src/main/java/net/kettlemc/kessentials/discord/listener/bukkit/DiscordAsyncChatListener.java
+++ b/src/main/java/net/kettlemc/kessentials/discord/listener/bukkit/DiscordAsyncChatListener.java
@@ -2,13 +2,11 @@ package net.kettlemc.kessentials.discord.listener.bukkit;
 
 import io.github.almightysatan.slams.Placeholder;
 import net.dv8tion.jda.api.utils.MarkdownSanitizer;
-import net.kettlemc.kcommon.bukkit.BukkitUtil;
+import net.kettlemc.kessentials.util.BukkitUtil;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
-import net.kettlemc.kcommon.luckperms.LuckPermsUtil;
 import net.kettlemc.kessentials.Essentials;
 import net.kettlemc.kessentials.config.DiscordConfiguration;
 import net.kettlemc.kessentials.config.Messages;
-import net.luckperms.api.LuckPermsProvider;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
@@ -22,7 +20,7 @@ public class DiscordAsyncChatListener implements Listener {
             return;
 
         // Get the player's prefix
-        String prefix = BukkitUtil.stripColor(LuckPermsUtil.getLuckPermsPrefix(LuckPermsProvider.get(), event.getPlayer()));
+        String prefix = BukkitUtil.stripColor(BukkitUtil.getLuckPermsPrefix(event.getPlayer()));
         if (prefix.isEmpty()) {
             prefix = DiscordConfiguration.DEFAULT_RANK.getValue();
         }

--- a/src/main/java/net/kettlemc/kessentials/discord/listener/bukkit/DiscordJoinQuitListener.java
+++ b/src/main/java/net/kettlemc/kessentials/discord/listener/bukkit/DiscordJoinQuitListener.java
@@ -2,8 +2,7 @@ package net.kettlemc.kessentials.discord.listener.bukkit;
 
 import io.github.almightysatan.slams.Placeholder;
 import net.dv8tion.jda.api.utils.MarkdownSanitizer;
-import net.kettlemc.kcommon.bukkit.BukkitUtil;
-import net.kettlemc.kcommon.java.StringUtil;
+import net.kettlemc.kessentials.util.BukkitUtil;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import net.kettlemc.kessentials.Essentials;
 import net.kettlemc.kessentials.config.DiscordConfiguration;
@@ -18,7 +17,7 @@ public class DiscordJoinQuitListener implements Listener {
     @EventHandler
     public void onJoin(PlayerJoinEvent event) {
 
-        String channel = StringUtil.stripEmojis(Essentials.instance().getDiscordBot().getMessageChannelById(DiscordConfiguration.DISCORD_CHANNEL_ID.getValue()).getName()).trim();
+        String channel = BukkitUtil.stripEmojis(Essentials.instance().getDiscordBot().getMessageChannelById(DiscordConfiguration.DISCORD_CHANNEL_ID.getValue()).getName()).trim();
 
         Essentials.instance().messages().sendMessage(event.getPlayer(), Messages.DISCORD_WELCOME_MESSAGE, Placeholder.of("channel", (ctx, args) -> channel));
 

--- a/src/main/java/net/kettlemc/kessentials/util/BukkitUtil.java
+++ b/src/main/java/net/kettlemc/kessentials/util/BukkitUtil.java
@@ -1,0 +1,85 @@
+package net.kettlemc.kessentials.util;
+
+import net.luckperms.api.LuckPerms;
+import net.luckperms.api.LuckPermsProvider;
+import net.luckperms.api.model.user.User;
+import net.luckperms.api.cacheddata.CachedMetaData;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+import org.bukkit.permissions.PermissionAttachmentInfo;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.regex.Pattern;
+
+/** Utility replacements for some features previously provided by kCommon. */
+public final class BukkitUtil {
+
+    private static final Pattern EMOJI_PATTERN = Pattern.compile("[^A-Za-z0-9 ]");
+
+    private BukkitUtil() {}
+
+    public static boolean isInteger(String value) {
+        if (value == null) return false;
+        try {
+            Integer.parseInt(value);
+            return true;
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+
+    public static int getPermissionAmount(Player player, String permissionLayout) {
+        if (player == null) return 0;
+        for (PermissionAttachmentInfo info : player.getEffectivePermissions()) {
+            String perm = info.getPermission();
+            if (!perm.startsWith(permissionLayout)) continue;
+            String suffix = perm.substring(permissionLayout.length());
+            if (suffix.startsWith(".")) suffix = suffix.substring(1);
+            if (isInteger(suffix)) {
+                return Integer.parseInt(suffix);
+            }
+        }
+        return 0;
+    }
+
+    public static String stripColor(String input) {
+        return input == null ? "" : ChatColor.stripColor(input);
+    }
+
+    public static String stripEmojis(String input) {
+        if (input == null) return "";
+        return EMOJI_PATTERN.matcher(input).replaceAll("");
+    }
+
+    public static void saveResource(Class<?> clazz, String resource, Path target) throws IOException {
+        if (Files.notExists(target.getParent())) {
+            Files.createDirectories(target.getParent());
+        }
+        try (InputStream in = clazz.getClassLoader().getResourceAsStream(resource)) {
+            if (in == null) {
+                throw new IOException("Resource not found: " + resource);
+            }
+            Files.copy(in, target, StandardCopyOption.REPLACE_EXISTING);
+        }
+    }
+
+    public static String getLuckPermsPrefix(Player player) {
+        if (Bukkit.getPluginManager().getPlugin("LuckPerms") == null) {
+            return "";
+        }
+        try {
+            LuckPerms lp = LuckPermsProvider.get();
+            User user = lp.getPlayerAdapter(Player.class).getUser(player);
+            CachedMetaData meta = user.getCachedData().getMetaData();
+            String prefix = meta.getPrefix();
+            return prefix == null ? "" : prefix;
+        } catch (Exception e) {
+            return "";
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- drop kCommon dependency from build
- clear the `kcommonVersion` property
- introduce local `ContentManager` and `BukkitUtil`
- use new utilities across commands and listeners

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68421b1669f48331b682834b9db115dd