### PR TITLE
Fix ContentManager plugin type

### DIFF
--- a/src/main/java/net/kettlemc/kessentials/content/ContentManager.java
+++ b/src/main/java/net/kettlemc/kessentials/content/ContentManager.java
@@ -1,23 +1,24 @@
 package net.kettlemc.kessentials.content;
 
 import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.PluginCommand;
 import org.bukkit.command.TabCompleter;
 import org.bukkit.event.Listener;
-import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.java.JavaPlugin;
 
 /**
  * Simple helper for registering commands and listeners.
  */
 public class ContentManager {
 
-    private final Plugin plugin;
+    private final JavaPlugin plugin;
 
-    public ContentManager(Plugin plugin) {
+    public ContentManager(JavaPlugin plugin) {
         this.plugin = plugin;
     }
 
     public void registerCommand(String name, CommandExecutor executor) {
-        var command = plugin.getCommand(name);
+        PluginCommand command = plugin.getCommand(name);
         if (command == null) {
             plugin.getLogger().warning("Command '" + name + "' is not defined in plugin.yml");
             return;


### PR DESCRIPTION
## Summary
- use `JavaPlugin` instead of `Plugin` in `ContentManager`
- use explicit `PluginCommand` variable when registering commands
- update imports accordingly

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684221752adc8331b731c3c32a9f224f