### PR TITLE
Shade Kyori dependencies

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -4,10 +4,11 @@ dependencies {
     // Use "implementation" for dependencies that are not shaded into the final jar
     // Use "internal" for dependencies that are shaded into the final jar
 
-    implementation "net.kyori:adventure-api:4.14.0"
-    implementation "net.kyori:adventure-text-minimessage:4.14.0"
-    implementation "net.kyori:adventure-platform-bukkit:4.3.0"
+    internal "net.kyori:adventure-api:4.14.0"
+    internal "net.kyori:adventure-text-minimessage:4.14.0"
+    internal "net.kyori:adventure-platform-bukkit:4.3.0"
     implementation "net.dv8tion:JDA:5.0.0-beta.24"
     implementation "net.luckperms:api:5.3"
     implementation "org.xerial:sqlite-jdbc:3.36.0.3"
 }
+


### PR DESCRIPTION
## Summary
- shade Adventure dependencies by marking them as `internal`

## Testing
- `./gradlew shadowJar` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68422cd579108331b81e30f805941ffa