### PR TITLE
Configure relocation for typesafe config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,6 +103,9 @@ if (jasklVersion && jasklImplementation) {
         dependencies {
             internal "io.github.almighty-satan.jaskl:jaskl-${jasklImplementation}:${jasklVersion}"
         }
+        shadowJar {
+            relocate 'com.typesafe.config', "net.kettlemc.${pluginName}.libs.typesafe.config"
+        }
     } else {
         dependencies {
             implementation "io.github.almighty-satan.jaskl:jaskl-${jasklImplementation}:${jasklVersion}"


### PR DESCRIPTION
## Summary
- add a `shadowJar` block in the `jasklShadow` section of `build.gradle`
- relocate `com.typesafe.config` into the plugin namespace

## Testing
- `./gradlew shadowJar` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6842cdd433c483319ea6d692f99cb7ef