### PR TITLE
Enable shading for SLAMS

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -35,7 +35,7 @@ jasklShadow = true
 slamsVersion = 1.1.2
 slamsParser = jackson
 slamsImplementation = minimessage
-slamsShadow = false
+slamsShadow = true
 
 # kLanguage settings (https://github.com/KettleMC-Network/kLanguage)
 # If you want to use kLanguage, insert the version and implementation here.


### PR DESCRIPTION
## Summary
- configure gradle to shade SLAMS in the plugin jar

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6842d2fdadac833192b075f45b5c803d