### PR TITLE
Update Shadow plugin to 8.1.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,8 @@
 
 plugins {
     id "java"
-    id "com.github.johnrengelman.shadow" version "7.0.0"
+    // Update Shadow plugin to handle class files from newer Java versions
+    id "com.github.johnrengelman.shadow" version "8.1.1"
 }
 
 


### PR DESCRIPTION
## Summary
- upgrade Shadow plugin in `build.gradle`

## Testing
- `gradle build --offline` *(fails: Plugin `com.github.johnrengelman.shadow` 8.1.1 was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842d47f99408331ba59e204c040105b