### PR TITLE
Fix freeze command metadata handling

### DIFF
--- a/src/main/java/net/kettlemc/kessentials/command/FreezeCommand.java
+++ b/src/main/java/net/kettlemc/kessentials/command/FreezeCommand.java
@@ -89,9 +89,10 @@ public class FreezeCommand implements CommandExecutor, TabCompleter {
 
     private static void setFrozen(Player player, boolean frozen) {
         if (frozen) {
-            player.removeMetadata(FROZEN_TAG, Essentials.instance().getPlugin());
+            player.setMetadata(FROZEN_TAG,
+                    new FixedMetadataValue(Essentials.instance().getPlugin(), true));
         } else {
-            player.setMetadata(FROZEN_TAG, new FixedMetadataValue(Essentials.instance().getPlugin(), true));
+            player.removeMetadata(FROZEN_TAG, Essentials.instance().getPlugin());
         }
     }
 


### PR DESCRIPTION
## Summary
- ensure FreezeCommand sets or removes frozen metadata correctly

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6842d9fef2b883318348554185f11c94