### PR TITLE
Fix frozen movement

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,6 +99,9 @@ dependencies {
     implementation fileTree(dir: "libs/implementation", include: "*.jar")
     internal fileTree(dir: "libs/internal", include: "*.jar")
     compileOnly "org.jetbrains:annotations:24.0.1"
+    testImplementation "org.junit.jupiter:junit-jupiter-api:5.9.2"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.9.2"
+    testImplementation "org.mockito:mockito-core:5.8.0"
 }
 
 if (jasklVersion && jasklImplementation) {
@@ -196,3 +199,7 @@ if (libby == "true") {
 }
 
 tasks.build.dependsOn shadowJar
+
+test {
+    useJUnitPlatform()
+}

--- a/src/main/java/net/kettlemc/kessentials/listener/PlayerMoveListener.java
+++ b/src/main/java/net/kettlemc/kessentials/listener/PlayerMoveListener.java
@@ -10,6 +10,7 @@ public class PlayerMoveListener implements Listener {
     @EventHandler
     public void onMove(PlayerMoveEvent event) {
         if (FreezeCommand.isFrozen(event.getPlayer())) {
+            event.setCancelled(true);
             return;
         }
 

--- a/src/test/java/net/kettlemc/kessentials/listener/PlayerMoveListenerTest.java
+++ b/src/test/java/net/kettlemc/kessentials/listener/PlayerMoveListenerTest.java
@@ -1,0 +1,38 @@
+package net.kettlemc.kessentials.listener;
+
+import net.kettlemc.kessentials.command.FreezeCommand;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerMoveEvent;
+import org.bukkit.metadata.FixedMetadataValue;
+import org.bukkit.plugin.Plugin;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class PlayerMoveListenerTest {
+
+    @Test
+    public void frozenPlayersCannotMove() {
+        Player player = Mockito.mock(Player.class);
+        World world = Mockito.mock(World.class);
+        Plugin plugin = Mockito.mock(Plugin.class);
+
+        Mockito.when(player.hasMetadata("kettlemc.essentials.frozen")).thenReturn(true);
+        Mockito.when(player.getMetadata("kettlemc.essentials.frozen"))
+                .thenReturn(Collections.singletonList(new FixedMetadataValue(plugin, true)));
+
+        Location from = new Location(world, 0, 0, 0);
+        Location to = new Location(world, 1, 0, 0);
+        PlayerMoveEvent event = new PlayerMoveEvent(player, from, to);
+
+        new PlayerMoveListener().onMove(event);
+
+        assertTrue(event.isCancelled(), "Frozen players should not be able to move");
+    }
+}
+


### PR DESCRIPTION
## Summary
- cancel `PlayerMoveEvent` when player is frozen
- depend on JUnit/Mockito for tests
- cover frozen movement in `PlayerMoveListenerTest`

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6842db405a848331a13a35e88ca7fdb5