### PR TITLE
Remove minimessage usage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -137,7 +137,6 @@ if (klanguageVersion) {
     dependencies {
         implementation "net.kettlemc.klanguage:klanguage-core:${klanguageVersion}"
         implementation "net.kettlemc.klanguage:klanguage-${klanguageImplementation}:${klanguageVersion}"
-        implementation 'net.kyori:adventure-text-minimessage:4.14.0'
         implementation 'net.kyori:adventure-platform-bukkit:4.3.0'
     }
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -5,7 +5,6 @@ dependencies {
     // Use "internal" for dependencies that are shaded into the final jar
 
     internal "net.kyori:adventure-api:4.14.0"
-    internal "net.kyori:adventure-text-minimessage:4.14.0"
     internal "net.kyori:adventure-platform-bukkit:4.3.0"
     implementation "net.dv8tion:JDA:5.0.0-beta.24"
     implementation "net.luckperms:api:5.3"

--- a/gradle.properties
+++ b/gradle.properties
@@ -34,7 +34,7 @@ jasklShadow = true
 # If SLAMS should be shadowed into the JAR file, enable slamsShadow.
 slamsVersion = 1.1.2
 slamsParser = jackson
-slamsImplementation = minimessage
+slamsImplementation = legacy
 slamsShadow = true
 
 # kLanguage settings (https://github.com/KettleMC-Network/kLanguage)

--- a/src/main/java/net/kettlemc/kessentials/command/FeedCommand.java
+++ b/src/main/java/net/kettlemc/kessentials/command/FeedCommand.java
@@ -1,6 +1,6 @@
 package net.kettlemc.kessentials.command;
 
-import io.github.almightysatan.slams.Placeholder;
+import net.kettlemc.kessentials.util.Placeholder;
 import net.kettlemc.kessentials.Essentials;
 import net.kettlemc.kessentials.config.Messages;
 import org.bukkit.Bukkit;
@@ -59,7 +59,7 @@ public class FeedCommand implements CommandExecutor, TabCompleter {
         Essentials.instance().messages().sendMessage(target, Messages.FEED_FED);
 
         if (sender != target) {
-            Essentials.instance().messages().sendMessage(sender, Messages.FEED_FED_OTHER, Placeholder.of("target", (ctx, args) -> target.getName()));
+            Essentials.instance().messages().sendMessage(sender, Messages.FEED_FED_OTHER, Placeholder.of("target", () -> target.getName()));
         }
     }
 

--- a/src/main/java/net/kettlemc/kessentials/command/FlyCommand.java
+++ b/src/main/java/net/kettlemc/kessentials/command/FlyCommand.java
@@ -1,6 +1,6 @@
 package net.kettlemc.kessentials.command;
 
-import io.github.almightysatan.slams.Placeholder;
+import net.kettlemc.kessentials.util.Placeholder;
 import net.kettlemc.kessentials.Essentials;
 import net.kettlemc.kessentials.config.Messages;
 import org.bukkit.Bukkit;
@@ -58,7 +58,7 @@ public class FlyCommand implements CommandExecutor, TabCompleter {
         target.setAllowFlight(!target.getAllowFlight());
         Essentials.instance().messages().sendMessage(target, target.getAllowFlight() ? Messages.FLY_ENABLED : Messages.FLY_DISABLED);
         if (sender != target) {
-            Essentials.instance().messages().sendMessage(sender, target.getAllowFlight() ? Messages.FLY_ENABLED_OTHER : Messages.FLY_DISABLED_OTHER, Placeholder.of("player", ((ctx, args) -> target.getName())));
+            Essentials.instance().messages().sendMessage(sender, target.getAllowFlight() ? Messages.FLY_ENABLED_OTHER : Messages.FLY_DISABLED_OTHER, Placeholder.of("player", () -> target.getName()));
         }
     }
 

--- a/src/main/java/net/kettlemc/kessentials/command/FreezeCommand.java
+++ b/src/main/java/net/kettlemc/kessentials/command/FreezeCommand.java
@@ -1,6 +1,6 @@
 package net.kettlemc.kessentials.command;
 
-import io.github.almightysatan.slams.Placeholder;
+import net.kettlemc.kessentials.util.Placeholder;
 import net.kettlemc.kessentials.Essentials;
 import net.kettlemc.kessentials.config.Messages;
 import org.bukkit.Bukkit;
@@ -71,7 +71,7 @@ public class FreezeCommand implements CommandExecutor, TabCompleter {
         }
 
         if (sender != target) {
-            Essentials.instance().messages().sendMessage(sender, isFrozen(target) ? Messages.FREEZE_FROZEN_OTHER : Messages.FREEZE_UNFROZEN_OTHER, Placeholder.of("target", ((ctx, args) -> target.getName())));
+            Essentials.instance().messages().sendMessage(sender, isFrozen(target) ? Messages.FREEZE_FROZEN_OTHER : Messages.FREEZE_UNFROZEN_OTHER, Placeholder.of("target", () -> target.getName()));
         }
     }
 

--- a/src/main/java/net/kettlemc/kessentials/command/GamemodeCommand.java
+++ b/src/main/java/net/kettlemc/kessentials/command/GamemodeCommand.java
@@ -1,6 +1,6 @@
 package net.kettlemc.kessentials.command;
 
-import io.github.almightysatan.slams.Placeholder;
+import net.kettlemc.kessentials.util.Placeholder;
 import net.kettlemc.kessentials.util.BukkitUtil;
 import net.kettlemc.kessentials.Essentials;
 import net.kettlemc.kessentials.config.Messages;
@@ -66,10 +66,10 @@ public class GamemodeCommand implements CommandExecutor, TabCompleter {
 
         target.setGameMode(gameMode);
 
-        Essentials.instance().messages().sendMessage(target, Messages.GAMEMODE_SET, Placeholder.of("gamemode", (ctx, args) -> gameMode.name()));
+        Essentials.instance().messages().sendMessage(target, Messages.GAMEMODE_SET, Placeholder.of("gamemode", () -> gameMode.name()));
 
         if (sender != target) {
-            Essentials.instance().messages().sendMessage(sender, Messages.GAMEMODE_SET_OTHER, Placeholder.of("gamemode", (ctx, args) -> gameMode.name()), Placeholder.of("target", (ctx, args) -> target.getName()));
+            Essentials.instance().messages().sendMessage(sender, Messages.GAMEMODE_SET_OTHER, Placeholder.of("gamemode", () -> gameMode.name()), Placeholder.of("target", () -> target.getName()));
         }
 
     }

--- a/src/main/java/net/kettlemc/kessentials/command/HealCommand.java
+++ b/src/main/java/net/kettlemc/kessentials/command/HealCommand.java
@@ -1,6 +1,6 @@
 package net.kettlemc.kessentials.command;
 
-import io.github.almightysatan.slams.Placeholder;
+import net.kettlemc.kessentials.util.Placeholder;
 import net.kettlemc.kessentials.Essentials;
 import net.kettlemc.kessentials.config.Messages;
 import org.bukkit.Bukkit;
@@ -61,7 +61,7 @@ public class HealCommand implements CommandExecutor, TabCompleter {
         Essentials.instance().messages().sendMessage(target, Messages.HEAL_HEALED);
 
         if (sender != target) {
-            Essentials.instance().messages().sendMessage(sender, Messages.HEAL_HEALED_OTHER, Placeholder.of("target", (ctx, args) -> target.getName()));
+            Essentials.instance().messages().sendMessage(sender, Messages.HEAL_HEALED_OTHER, Placeholder.of("target", () -> target.getName()));
         }
     }
 

--- a/src/main/java/net/kettlemc/kessentials/command/MaterialCommand.java
+++ b/src/main/java/net/kettlemc/kessentials/command/MaterialCommand.java
@@ -1,6 +1,6 @@
 package net.kettlemc.kessentials.command;
 
-import io.github.almightysatan.slams.Placeholder;
+import net.kettlemc.kessentials.util.Placeholder;
 import net.kettlemc.kessentials.Essentials;
 import net.kettlemc.kessentials.config.Messages;
 import org.bukkit.Material;
@@ -35,7 +35,7 @@ public class MaterialCommand implements CommandExecutor, TabCompleter {
         Material material = itemStack.getType();
         int damage = itemStack.getDurability();
 
-        Essentials.instance().messages().sendMessage(player, Messages.MATERIAL, Placeholder.of("material", (p, ctx) -> material.name()), Placeholder.of("damage", (p, ctx) -> String.valueOf(damage)));
+        Essentials.instance().messages().sendMessage(player, Messages.MATERIAL, Placeholder.of("material", () -> material.name()), Placeholder.of("damage", () -> String.valueOf(damage)));
 
         return true;
 

--- a/src/main/java/net/kettlemc/kessentials/command/RepairCommand.java
+++ b/src/main/java/net/kettlemc/kessentials/command/RepairCommand.java
@@ -1,6 +1,6 @@
 package net.kettlemc.kessentials.command;
 
-import io.github.almightysatan.slams.Placeholder;
+import net.kettlemc.kessentials.util.Placeholder;
 import net.kettlemc.kessentials.Essentials;
 import net.kettlemc.kessentials.config.Messages;
 import org.bukkit.Bukkit;
@@ -71,7 +71,7 @@ public class RepairCommand implements CommandExecutor, TabCompleter {
             Essentials.instance().messages().sendMessage(target, Messages.REPAIR_NOT_REPAIRABLE);
 
             if (sender != target) {
-                Essentials.instance().messages().sendMessage(sender, Messages.REPAIR_NOT_REPAIRABLE_OTHER, Placeholder.of("target", (ctx, args) -> target.getName()));
+                Essentials.instance().messages().sendMessage(sender, Messages.REPAIR_NOT_REPAIRABLE_OTHER, Placeholder.of("target", () -> target.getName()));
             }
 
             return;
@@ -82,7 +82,7 @@ public class RepairCommand implements CommandExecutor, TabCompleter {
         Essentials.instance().messages().sendMessage(target, Messages.REPAIR_REPAIRED);
 
         if (sender != target) {
-            Essentials.instance().messages().sendMessage(sender, Messages.REPAIR_REPAIRED_OTHER, Placeholder.of("target", (ctx, args) -> target.getName()));
+            Essentials.instance().messages().sendMessage(sender, Messages.REPAIR_REPAIRED_OTHER, Placeholder.of("target", () -> target.getName()));
         }
     }
 

--- a/src/main/java/net/kettlemc/kessentials/command/SpeedCommand.java
+++ b/src/main/java/net/kettlemc/kessentials/command/SpeedCommand.java
@@ -1,6 +1,6 @@
 package net.kettlemc.kessentials.command;
 
-import io.github.almightysatan.slams.Placeholder;
+import net.kettlemc.kessentials.util.Placeholder;
 import net.kettlemc.kessentials.util.BukkitUtil;
 import net.kettlemc.kessentials.Essentials;
 import net.kettlemc.kessentials.config.Messages;
@@ -70,15 +70,15 @@ public class SpeedCommand implements CommandExecutor, TabCompleter {
 
         if (target.isFlying()) {
             target.setFlySpeed(getRealMoveSpeed(speed, true));
-            Essentials.instance().messages().sendMessage(target, Messages.SPEED_SET_FLYING, Placeholder.of("speed", (ctx, args) -> String.valueOf(speed)));
+            Essentials.instance().messages().sendMessage(target, Messages.SPEED_SET_FLYING, Placeholder.of("speed", () -> String.valueOf(speed)));
             if (sender != target) {
-                Essentials.instance().messages().sendMessage(sender, Messages.SPEED_SET_FLYING_OTHER, Placeholder.of("speed", (ctx, args) -> String.valueOf(speed)), Placeholder.of("player", (ctx, args) -> target.getName()));
+                Essentials.instance().messages().sendMessage(sender, Messages.SPEED_SET_FLYING_OTHER, Placeholder.of("speed", () -> String.valueOf(speed)), Placeholder.of("player", () -> target.getName()));
             }
         } else {
             target.setWalkSpeed(getRealMoveSpeed(speed, false));
-            Essentials.instance().messages().sendMessage(target, Messages.SPEED_SET_WALKING, Placeholder.of("speed", (ctx, args) -> String.valueOf(speed)));
+            Essentials.instance().messages().sendMessage(target, Messages.SPEED_SET_WALKING, Placeholder.of("speed", () -> String.valueOf(speed)));
             if (sender != target) {
-                Essentials.instance().messages().sendMessage(sender, Messages.SPEED_SET_WALKING_OTHER, Placeholder.of("speed", (ctx, args) -> String.valueOf(speed)), Placeholder.of("player", (ctx, args) -> target.getName()));
+                Essentials.instance().messages().sendMessage(sender, Messages.SPEED_SET_WALKING_OTHER, Placeholder.of("speed", () -> String.valueOf(speed)), Placeholder.of("player", () -> target.getName()));
             }
         }
     }

--- a/src/main/java/net/kettlemc/kessentials/command/TeleportPlayerCommand.java
+++ b/src/main/java/net/kettlemc/kessentials/command/TeleportPlayerCommand.java
@@ -1,6 +1,6 @@
 package net.kettlemc.kessentials.command;
 
-import io.github.almightysatan.slams.Placeholder;
+import net.kettlemc.kessentials.util.Placeholder;
 import net.kettlemc.kessentials.Essentials;
 import net.kettlemc.kessentials.config.Messages;
 import org.bukkit.Bukkit;
@@ -37,7 +37,7 @@ public class TeleportPlayerCommand implements CommandExecutor, TabCompleter {
                 }
 
                 player.teleport(target.getLocation());
-                Essentials.instance().messages().sendMessage(sender, Messages.TELEPORT_TELEPORTED, Placeholder.of("target", ((ctx, args1) -> target.getName())));
+                Essentials.instance().messages().sendMessage(sender, Messages.TELEPORT_TELEPORTED, Placeholder.of("target", () -> target.getName()));
             } else {
                 Essentials.instance().messages().sendMessage(sender, Messages.TELEPORT_USAGE);
             }
@@ -57,7 +57,7 @@ public class TeleportPlayerCommand implements CommandExecutor, TabCompleter {
             }
 
             player.teleport(target.getLocation());
-            Essentials.instance().messages().sendMessage(sender, Messages.TELEPORT_TELEPORTED_OTHER, Placeholder.of("player", ((ctx, arguments) -> player.getName())), Placeholder.of("target", ((ctx, args1) -> target.getName())));
+            Essentials.instance().messages().sendMessage(sender, Messages.TELEPORT_TELEPORTED_OTHER, Placeholder.of("player", () -> player.getName()), Placeholder.of("target", () -> target.getName()));
         } else {
             Essentials.instance().messages().sendMessage(sender, Messages.TELEPORT_USAGE);
         }

--- a/src/main/java/net/kettlemc/kessentials/command/TimeCommands.java
+++ b/src/main/java/net/kettlemc/kessentials/command/TimeCommands.java
@@ -1,6 +1,6 @@
 package net.kettlemc.kessentials.command;
 
-import io.github.almightysatan.slams.minimessage.AdventureMessage;
+import net.kettlemc.kessentials.util.Message;
 import net.kettlemc.kessentials.Essentials;
 import net.kettlemc.kessentials.config.Messages;
 import org.bukkit.Bukkit;
@@ -16,7 +16,7 @@ import java.util.stream.Collectors;
 public class TimeCommands implements CommandExecutor, TabCompleter {
 
     public static final Map<String, Integer> TIME_MAP = new HashMap<>();
-    public static final Map<String, AdventureMessage> MESSAGE_MAP = new HashMap<>();
+    public static final Map<String, Message> MESSAGE_MAP = new HashMap<>();
 
     static {
         TIME_MAP.put("morning", 23500);
@@ -72,7 +72,7 @@ public class TimeCommands implements CommandExecutor, TabCompleter {
      * @param time           The time to set the world to
      * @param successMessage The message to send to the sender if the time was set successfully
      */
-    private void setTime(CommandSender sender, World world, int time, AdventureMessage successMessage) {
+    private void setTime(CommandSender sender, World world, int time, Message successMessage) {
 
         if (sender instanceof ConsoleCommandSender && world == null) {
             Essentials.instance().messages().sendMessage(sender, Messages.TIME_USAGE);

--- a/src/main/java/net/kettlemc/kessentials/command/VanishCommand.java
+++ b/src/main/java/net/kettlemc/kessentials/command/VanishCommand.java
@@ -1,6 +1,6 @@
 package net.kettlemc.kessentials.command;
 
-import io.github.almightysatan.slams.Placeholder;
+import net.kettlemc.kessentials.util.Placeholder;
 import net.kettlemc.kessentials.Essentials;
 import net.kettlemc.kessentials.config.Messages;
 import org.bukkit.Bukkit;
@@ -80,7 +80,7 @@ public class VanishCommand implements CommandExecutor, TabCompleter {
         }
 
         if (sender != target) {
-            Essentials.instance().messages().sendMessage(sender, isVanished(target) ? Messages.VANISH_VANISHED_OTHER : Messages.VANISH_UNVANISHED_OTHER, Placeholder.of("target", ((ctx, args) -> target.getName())));
+            Essentials.instance().messages().sendMessage(sender, isVanished(target) ? Messages.VANISH_VANISHED_OTHER : Messages.VANISH_UNVANISHED_OTHER, Placeholder.of("target", () -> target.getName()));
         }
     }
 

--- a/src/main/java/net/kettlemc/kessentials/command/home/DeleteHomeCommand.java
+++ b/src/main/java/net/kettlemc/kessentials/command/home/DeleteHomeCommand.java
@@ -1,6 +1,6 @@
 package net.kettlemc.kessentials.command.home;
 
-import io.github.almightysatan.slams.Placeholder;
+import net.kettlemc.kessentials.util.Placeholder;
 import net.kettlemc.kessentials.Essentials;
 import net.kettlemc.kessentials.config.Messages;
 import net.kettlemc.kessentials.teleport.Warp;
@@ -39,7 +39,7 @@ public class DeleteHomeCommand implements CommandExecutor, TabCompleter {
         }
 
         Essentials.instance().homeHandler().removeHome(home);
-        Essentials.instance().messages().sendMessage(player, Messages.HOME_DELETED, Placeholder.of("name", (ctx, args1) -> home.name()));
+        Essentials.instance().messages().sendMessage(player, Messages.HOME_DELETED, Placeholder.of("name", () -> home.name()));
 
         return true;
     }

--- a/src/main/java/net/kettlemc/kessentials/command/home/HomeCommand.java
+++ b/src/main/java/net/kettlemc/kessentials/command/home/HomeCommand.java
@@ -1,6 +1,6 @@
 package net.kettlemc.kessentials.command.home;
 
-import io.github.almightysatan.slams.Placeholder;
+import net.kettlemc.kessentials.util.Placeholder;
 import net.kettlemc.kessentials.Essentials;
 import net.kettlemc.kessentials.config.Configuration;
 import net.kettlemc.kessentials.config.Messages;
@@ -38,7 +38,7 @@ public class HomeCommand implements CommandExecutor, TabCompleter {
             Essentials.instance().messages().sendMessage(player, Messages.HOME_LIST_HEADER);
             Essentials.instance().homeHandler().getHomes(player.getUniqueId()).forEach(
                     home -> Essentials.instance().messages().sendMessage(player, Messages.HOME_LIST_ENTRY,
-                            Placeholder.of("name", (ctx, argument) -> home.name()))
+                            Placeholder.of("name", () -> home.name()))
             );
             return true;
         }

--- a/src/main/java/net/kettlemc/kessentials/command/home/SetHomeCommand.java
+++ b/src/main/java/net/kettlemc/kessentials/command/home/SetHomeCommand.java
@@ -1,6 +1,6 @@
 package net.kettlemc.kessentials.command.home;
 
-import io.github.almightysatan.slams.Placeholder;
+import net.kettlemc.kessentials.util.Placeholder;
 import net.kettlemc.kessentials.util.BukkitUtil;
 import net.kettlemc.kessentials.Essentials;
 import net.kettlemc.kessentials.config.Configuration;
@@ -42,7 +42,7 @@ public class SetHomeCommand implements CommandExecutor, TabCompleter {
 
         int maxHomes = maxHomes(player);
         if (Essentials.instance().homeHandler().getHomes(player.getUniqueId()).size() >= maxHomes) {
-            Essentials.instance().messages().sendMessage(player, Messages.HOME_MAX_HOMES_REACHED, Placeholder.of("max", (ctx, args1) -> String.valueOf(maxHomes)));
+            Essentials.instance().messages().sendMessage(player, Messages.HOME_MAX_HOMES_REACHED, Placeholder.of("max", () -> String.valueOf(maxHomes)));
             return true;
         }
 
@@ -58,7 +58,7 @@ public class SetHomeCommand implements CommandExecutor, TabCompleter {
 
         Warp home = new Warp(player.getUniqueId(), args[0], player.getLocation());
         Essentials.instance().homeHandler().addHome(home);
-        Essentials.instance().messages().sendMessage(player, Messages.HOME_SET, Placeholder.of("name", (ctx, args1) -> home.name()));
+        Essentials.instance().messages().sendMessage(player, Messages.HOME_SET, Placeholder.of("name", () -> home.name()));
 
         return true;
     }

--- a/src/main/java/net/kettlemc/kessentials/command/tpa/TPACommand.java
+++ b/src/main/java/net/kettlemc/kessentials/command/tpa/TPACommand.java
@@ -1,6 +1,6 @@
 package net.kettlemc.kessentials.command.tpa;
 
-import io.github.almightysatan.slams.Placeholder;
+import net.kettlemc.kessentials.util.Placeholder;
 import net.kettlemc.kessentials.Essentials;
 import net.kettlemc.kessentials.config.Messages;
 import net.kettlemc.kessentials.teleport.TeleportRequest;
@@ -30,16 +30,16 @@ public class TPACommand implements CommandExecutor, TabCompleter {
 
         if (TeleportRequest.request(requester, target)) {
             Essentials.instance().messages().sendMessage(requester, Messages.TPA_REQUEST_SENT,
-                    Placeholder.of("target", (ctx, args) -> target.getName()));
+                    Placeholder.of("target", () -> target.getName()));
             Essentials.instance().messages().sendMessage(target, Messages.TPA_REQUEST_RECEIVED,
-                    Placeholder.of("requester", (ctx, args) -> requester.getName()));
+                    Placeholder.of("requester", () -> requester.getName()));
             Essentials.instance().messages().sendMessage(target, Messages.TPA_REQUEST_ACCEPT,
-                    Placeholder.of("requester", (ctx, args) -> requester.getName()));
+                    Placeholder.of("requester", () -> requester.getName()));
             Essentials.instance().messages().sendMessage(target, Messages.TPA_REQUEST_DENY,
-                    Placeholder.of("requester", (ctx, args) -> requester.getName()));
+                    Placeholder.of("requester", () -> requester.getName()));
 
         } else {
-            Essentials.instance().messages().sendMessage(requester, Messages.TPA_REQUEST_ALREADY_SENT, Placeholder.of("target", (ctx, args) -> target.getName()));
+            Essentials.instance().messages().sendMessage(requester, Messages.TPA_REQUEST_ALREADY_SENT, Placeholder.of("target", () -> target.getName()));
         }
     }
 

--- a/src/main/java/net/kettlemc/kessentials/command/tpa/TPAcceptCommand.java
+++ b/src/main/java/net/kettlemc/kessentials/command/tpa/TPAcceptCommand.java
@@ -1,6 +1,6 @@
 package net.kettlemc.kessentials.command.tpa;
 
-import io.github.almightysatan.slams.Placeholder;
+import net.kettlemc.kessentials.util.Placeholder;
 import net.kettlemc.kessentials.Essentials;
 import net.kettlemc.kessentials.config.Configuration;
 import net.kettlemc.kessentials.config.Messages;
@@ -29,13 +29,13 @@ public class TPAcceptCommand implements CommandExecutor, TabCompleter {
         }
 
         if (TeleportRequest.getRequestsFor(target).contains(requester)) {
-            Essentials.instance().messages().sendMessage(requester, Messages.TPA_REQUEST_ACCEPTED, Placeholder.of("target", (ctx, args) -> target.getName()));
-            Essentials.instance().messages().sendMessage(target, Messages.TPA_TPACCEPT, Placeholder.of("requester", (ctx, args) -> requester.getName()));
+            Essentials.instance().messages().sendMessage(requester, Messages.TPA_REQUEST_ACCEPTED, Placeholder.of("target", () -> target.getName()));
+            Essentials.instance().messages().sendMessage(target, Messages.TPA_TPACCEPT, Placeholder.of("requester", () -> requester.getName()));
             Teleportation.schedule(Teleportation.prepare(requester, target.getLocation(), Configuration.TELEPORT_COUNTDOWN_SECONDS.getValue(), () -> TeleportRequest.remove(target, requester)));
 
 
         } else {
-            Essentials.instance().messages().sendMessage(target, Messages.TPA_LIST_NO_REQUEST, Placeholder.of("requester", (ctx, args) -> requester.getName()));
+            Essentials.instance().messages().sendMessage(target, Messages.TPA_LIST_NO_REQUEST, Placeholder.of("requester", () -> requester.getName()));
         }
     }
 

--- a/src/main/java/net/kettlemc/kessentials/command/tpa/TPDenyCommand.java
+++ b/src/main/java/net/kettlemc/kessentials/command/tpa/TPDenyCommand.java
@@ -1,6 +1,6 @@
 package net.kettlemc.kessentials.command.tpa;
 
-import io.github.almightysatan.slams.Placeholder;
+import net.kettlemc.kessentials.util.Placeholder;
 import net.kettlemc.kessentials.Essentials;
 import net.kettlemc.kessentials.config.Messages;
 import net.kettlemc.kessentials.teleport.TeleportRequest;
@@ -27,13 +27,13 @@ public class TPDenyCommand implements CommandExecutor, TabCompleter {
         }
 
         if (TeleportRequest.getRequestsFor(target).contains(requester)) {
-            Essentials.instance().messages().sendMessage(requester, Messages.TPA_REQUEST_DENIED, Placeholder.of("target", (ctx, args) -> target.getName()));
-            Essentials.instance().messages().sendMessage(target, Messages.TPA_TPDENY, Placeholder.of("requester", (ctx, args) -> requester.getName()));
+            Essentials.instance().messages().sendMessage(requester, Messages.TPA_REQUEST_DENIED, Placeholder.of("target", () -> target.getName()));
+            Essentials.instance().messages().sendMessage(target, Messages.TPA_TPDENY, Placeholder.of("requester", () -> requester.getName()));
             TeleportRequest.remove(target, requester);
 
 
         } else {
-            Essentials.instance().messages().sendMessage(target, Messages.TPA_LIST_NO_REQUEST, Placeholder.of("requester", (ctx, args) -> requester.getName()));
+            Essentials.instance().messages().sendMessage(target, Messages.TPA_LIST_NO_REQUEST, Placeholder.of("requester", () -> requester.getName()));
         }
     }
 

--- a/src/main/java/net/kettlemc/kessentials/command/tpa/TPListCommand.java
+++ b/src/main/java/net/kettlemc/kessentials/command/tpa/TPListCommand.java
@@ -1,6 +1,6 @@
 package net.kettlemc.kessentials.command.tpa;
 
-import io.github.almightysatan.slams.Placeholder;
+import net.kettlemc.kessentials.util.Placeholder;
 import net.kettlemc.kessentials.Essentials;
 import net.kettlemc.kessentials.config.Messages;
 import net.kettlemc.kessentials.teleport.TeleportRequest;
@@ -33,7 +33,7 @@ public class TPListCommand implements CommandExecutor, TabCompleter {
         Essentials.instance().messages().sendMessage(target, Messages.TPA_LIST);
 
         TeleportRequest.getRequestsFor(target).forEach(
-                requester -> Essentials.instance().messages().sendMessage(target, Messages.TPA_LIST_ENTRY, Placeholder.of("requester", (ctx, args1) -> requester.getName()))
+                requester -> Essentials.instance().messages().sendMessage(target, Messages.TPA_LIST_ENTRY, Placeholder.of("requester", () -> requester.getName()))
         );
 
         return true;

--- a/src/main/java/net/kettlemc/kessentials/command/warp/DeleteWarpCommand.java
+++ b/src/main/java/net/kettlemc/kessentials/command/warp/DeleteWarpCommand.java
@@ -1,6 +1,6 @@
 package net.kettlemc.kessentials.command.warp;
 
-import io.github.almightysatan.slams.Placeholder;
+import net.kettlemc.kessentials.util.Placeholder;
 import net.kettlemc.kessentials.Essentials;
 import net.kettlemc.kessentials.config.Messages;
 import net.kettlemc.kessentials.teleport.Warp;
@@ -44,7 +44,7 @@ public class DeleteWarpCommand implements CommandExecutor, TabCompleter {
         }
 
         Essentials.instance().warpHandler().removeWarp(warp);
-        Essentials.instance().messages().sendMessage(player, Messages.WARP_DELETED, Placeholder.of("name", (ctx, args1) -> warp.name()));
+        Essentials.instance().messages().sendMessage(player, Messages.WARP_DELETED, Placeholder.of("name", () -> warp.name()));
 
         return true;
     }

--- a/src/main/java/net/kettlemc/kessentials/command/warp/SetWarpCommand.java
+++ b/src/main/java/net/kettlemc/kessentials/command/warp/SetWarpCommand.java
@@ -1,6 +1,6 @@
 package net.kettlemc.kessentials.command.warp;
 
-import io.github.almightysatan.slams.Placeholder;
+import net.kettlemc.kessentials.util.Placeholder;
 import net.kettlemc.kessentials.Essentials;
 import net.kettlemc.kessentials.config.Configuration;
 import net.kettlemc.kessentials.config.Messages;
@@ -57,7 +57,7 @@ public class SetWarpCommand implements CommandExecutor, TabCompleter {
 
         Warp warp = new Warp(args[0], player.getLocation());
         Essentials.instance().warpHandler().addWarp(warp);
-        Essentials.instance().messages().sendMessage(player, Messages.WARP_SET, Placeholder.of("name", (ctx, args1) -> warp.name()));
+        Essentials.instance().messages().sendMessage(player, Messages.WARP_SET, Placeholder.of("name", () -> warp.name()));
 
         return true;
     }

--- a/src/main/java/net/kettlemc/kessentials/command/warp/WarpCommand.java
+++ b/src/main/java/net/kettlemc/kessentials/command/warp/WarpCommand.java
@@ -1,6 +1,6 @@
 package net.kettlemc.kessentials.command.warp;
 
-import io.github.almightysatan.slams.Placeholder;
+import net.kettlemc.kessentials.util.Placeholder;
 import net.kettlemc.kessentials.Essentials;
 import net.kettlemc.kessentials.config.Configuration;
 import net.kettlemc.kessentials.config.Messages;
@@ -38,7 +38,7 @@ public class WarpCommand implements CommandExecutor, TabCompleter {
             Essentials.instance().messages().sendMessage(player, Messages.WARP_LIST_HEADER);
             Essentials.instance().warpHandler().getWarps().forEach(
                     warp -> Essentials.instance().messages().sendMessage(player, Messages.WARP_LIST_ENTRY,
-                            Placeholder.of("name", (ctx, argument) -> warp.name()))
+                            Placeholder.of("name", () -> warp.name()))
             );
             return true;
         }

--- a/src/main/java/net/kettlemc/kessentials/config/Messages.java
+++ b/src/main/java/net/kettlemc/kessentials/config/Messages.java
@@ -1,224 +1,222 @@
 package net.kettlemc.kessentials.config;
 
-import io.github.almightysatan.slams.Slams;
-import io.github.almightysatan.slams.minimessage.AdventureMessage;
-import io.github.almightysatan.slams.parser.JacksonParser;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import net.kettlemc.kessentials.util.BukkitUtil;
+import net.kettlemc.kessentials.util.Message;
 
-import java.io.File;
 import java.io.IOException;
-import java.net.URISyntaxException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Locale;
-import java.util.Objects;
+import java.util.Map;
 
 public class Messages {
 
     private static final Path LANGUAGE_PATH = Paths.get("plugins", "kEssentials", "languages");
-    private static final Slams LANGUAGE_MANAGER = Slams.create(getDefaultLocale());
+    private static Map<String, Object> LANGUAGE_DATA;
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
-    public static final AdventureMessage PREFIX = AdventureMessage.of("messages.common.prefix", LANGUAGE_MANAGER);
-    public static final AdventureMessage NO_PERMISSION = AdventureMessage.of("messages.common.no-permission", LANGUAGE_MANAGER);
-    public static final AdventureMessage PLAYER_ONLY = AdventureMessage.of("messages.common.player-only", LANGUAGE_MANAGER);
-    public static final AdventureMessage CONSOLE_ONLY = AdventureMessage.of("messages.common.console-only", LANGUAGE_MANAGER);
-    public static final AdventureMessage PLAYER_NOT_FOUND = AdventureMessage.of("messages.common.player-not-found", LANGUAGE_MANAGER);
-    public static final AdventureMessage COMMAND_DISABLED = AdventureMessage.of("messages.common.command-disabled", LANGUAGE_MANAGER);
+    public static final Message PREFIX = Message.of("messages.common.prefix");
+    public static final Message NO_PERMISSION = Message.of("messages.common.no-permission");
+    public static final Message PLAYER_ONLY = Message.of("messages.common.player-only");
+    public static final Message CONSOLE_ONLY = Message.of("messages.common.console-only");
+    public static final Message PLAYER_NOT_FOUND = Message.of("messages.common.player-not-found");
+    public static final Message COMMAND_DISABLED = Message.of("messages.common.command-disabled");
 
-    public static final AdventureMessage RESTART = AdventureMessage.of("messages.common.restart", LANGUAGE_MANAGER);
-    public static final AdventureMessage TIMEUNIT_SECOND = AdventureMessage.of("messages.common.timeunit.second", LANGUAGE_MANAGER);
-    public static final AdventureMessage TIMEUNIT_SECONDS = AdventureMessage.of("messages.common.timeunit.seconds", LANGUAGE_MANAGER);
-    public static final AdventureMessage TIMEUNIT_MINUTE = AdventureMessage.of("messages.common.timeunit.minute", LANGUAGE_MANAGER);
-    public static final AdventureMessage TIMEUNIT_MINUTES = AdventureMessage.of("messages.common.timeunit.minutes", LANGUAGE_MANAGER);
-    public static final AdventureMessage TIMEUNIT_HOUR = AdventureMessage.of("messages.common.timeunit.hour", LANGUAGE_MANAGER);
-    public static final AdventureMessage TIMEUNIT_HOURS = AdventureMessage.of("messages.common.timeunit.hours", LANGUAGE_MANAGER);
+    public static final Message RESTART = Message.of("messages.common.restart");
+    public static final Message TIMEUNIT_SECOND = Message.of("messages.common.timeunit.second");
+    public static final Message TIMEUNIT_SECONDS = Message.of("messages.common.timeunit.seconds");
+    public static final Message TIMEUNIT_MINUTE = Message.of("messages.common.timeunit.minute");
+    public static final Message TIMEUNIT_MINUTES = Message.of("messages.common.timeunit.minutes");
+    public static final Message TIMEUNIT_HOUR = Message.of("messages.common.timeunit.hour");
+    public static final Message TIMEUNIT_HOURS = Message.of("messages.common.timeunit.hours");
 
-    public static final AdventureMessage JOIN_MESSAGE = AdventureMessage.of("messages.common.join", LANGUAGE_MANAGER);
-    public static final AdventureMessage QUIT_MESSAGE = AdventureMessage.of("messages.common.quit", LANGUAGE_MANAGER);
+    public static final Message JOIN_MESSAGE = Message.of("messages.common.join");
+    public static final Message QUIT_MESSAGE = Message.of("messages.common.quit");
 
-    public static final AdventureMessage TELEPORTATION_CANCELLED = AdventureMessage.of("messages.teleport.teleportation-cancelled", LANGUAGE_MANAGER);
-    public static final AdventureMessage TELEPORTATION_SUCCESSFUL = AdventureMessage.of("messages.teleport.teleportation-successful", LANGUAGE_MANAGER);
-    public static final AdventureMessage TELEPORTATION_COOLDOWN = AdventureMessage.of("messages.teleport.teleportation-cooldown", LANGUAGE_MANAGER);
+    public static final Message TELEPORTATION_CANCELLED = Message.of("messages.teleport.teleportation-cancelled");
+    public static final Message TELEPORTATION_SUCCESSFUL = Message.of("messages.teleport.teleportation-successful");
+    public static final Message TELEPORTATION_COOLDOWN = Message.of("messages.teleport.teleportation-cooldown");
 
-    public static final AdventureMessage GAMEMODE_SET = AdventureMessage.of("messages.gamemode.set", LANGUAGE_MANAGER);
-    public static final AdventureMessage GAMEMODE_SET_OTHER = AdventureMessage.of("messages.gamemode.set-other", LANGUAGE_MANAGER);
-    public static final AdventureMessage GAMEMODE_INVALID = AdventureMessage.of("messages.gamemode.invalid", LANGUAGE_MANAGER);
-    public static final AdventureMessage GAMEMODE_USAGE = AdventureMessage.of("messages.gamemode.usage", LANGUAGE_MANAGER);
+    public static final Message GAMEMODE_SET = Message.of("messages.gamemode.set");
+    public static final Message GAMEMODE_SET_OTHER = Message.of("messages.gamemode.set-other");
+    public static final Message GAMEMODE_INVALID = Message.of("messages.gamemode.invalid");
+    public static final Message GAMEMODE_USAGE = Message.of("messages.gamemode.usage");
 
-    public static final AdventureMessage FLY_ENABLED = AdventureMessage.of("messages.fly.enabled", LANGUAGE_MANAGER);
-    public static final AdventureMessage FLY_ENABLED_OTHER = AdventureMessage.of("messages.fly.enabled-other", LANGUAGE_MANAGER);
-    public static final AdventureMessage FLY_DISABLED = AdventureMessage.of("messages.fly.disabled", LANGUAGE_MANAGER);
-    public static final AdventureMessage FLY_DISABLED_OTHER = AdventureMessage.of("messages.fly.disabled-other", LANGUAGE_MANAGER);
-    public static final AdventureMessage FLY_USAGE = AdventureMessage.of("messages.fly.usage", LANGUAGE_MANAGER);
+    public static final Message FLY_ENABLED = Message.of("messages.fly.enabled");
+    public static final Message FLY_ENABLED_OTHER = Message.of("messages.fly.enabled-other");
+    public static final Message FLY_DISABLED = Message.of("messages.fly.disabled");
+    public static final Message FLY_DISABLED_OTHER = Message.of("messages.fly.disabled-other");
+    public static final Message FLY_USAGE = Message.of("messages.fly.usage");
 
-    public static final AdventureMessage SPEED_SET_WALKING = AdventureMessage.of("messages.speed.set.walking", LANGUAGE_MANAGER);
-    public static final AdventureMessage SPEED_SET_FLYING = AdventureMessage.of("messages.speed.set.flying", LANGUAGE_MANAGER);
-    public static final AdventureMessage SPEED_SET_WALKING_OTHER = AdventureMessage.of("messages.speed.set-other.walking", LANGUAGE_MANAGER);
-    public static final AdventureMessage SPEED_SET_FLYING_OTHER = AdventureMessage.of("messages.speed.set-other.flying", LANGUAGE_MANAGER);
-    public static final AdventureMessage SPEED_INVALID = AdventureMessage.of("messages.speed.invalid", LANGUAGE_MANAGER);
-    public static final AdventureMessage SPEED_USAGE = AdventureMessage.of("messages.speed.usage", LANGUAGE_MANAGER);
+    public static final Message SPEED_SET_WALKING = Message.of("messages.speed.set.walking");
+    public static final Message SPEED_SET_FLYING = Message.of("messages.speed.set.flying");
+    public static final Message SPEED_SET_WALKING_OTHER = Message.of("messages.speed.set-other.walking");
+    public static final Message SPEED_SET_FLYING_OTHER = Message.of("messages.speed.set-other.flying");
+    public static final Message SPEED_INVALID = Message.of("messages.speed.invalid");
+    public static final Message SPEED_USAGE = Message.of("messages.speed.usage");
 
-    public static final AdventureMessage TELEPORT_TELEPORTED = AdventureMessage.of("messages.teleport.teleported", LANGUAGE_MANAGER);
-    public static final AdventureMessage TELEPORT_TELEPORTED_OTHER = AdventureMessage.of("messages.teleport.teleported-other", LANGUAGE_MANAGER);
-    public static final AdventureMessage TELEPORT_USAGE = AdventureMessage.of("messages.teleport.usage", LANGUAGE_MANAGER);
-    public static final AdventureMessage TELEPORT_ALREADY_SCHEDULED = AdventureMessage.of("messages.teleport.already-scheduled", LANGUAGE_MANAGER);
+    public static final Message TELEPORT_TELEPORTED = Message.of("messages.teleport.teleported");
+    public static final Message TELEPORT_TELEPORTED_OTHER = Message.of("messages.teleport.teleported-other");
+    public static final Message TELEPORT_USAGE = Message.of("messages.teleport.usage");
+    public static final Message TELEPORT_ALREADY_SCHEDULED = Message.of("messages.teleport.already-scheduled");
 
-    public static final AdventureMessage FREEZE_FROZEN = AdventureMessage.of("messages.freeze.frozen", LANGUAGE_MANAGER);
-    public static final AdventureMessage FREEZE_FROZEN_OTHER = AdventureMessage.of("messages.freeze.frozen-other", LANGUAGE_MANAGER);
-    public static final AdventureMessage FREEZE_UNFROZEN = AdventureMessage.of("messages.freeze.unfrozen", LANGUAGE_MANAGER);
-    public static final AdventureMessage FREEZE_UNFROZEN_OTHER = AdventureMessage.of("messages.freeze.unfrozen-other", LANGUAGE_MANAGER);
-    public static final AdventureMessage FREEZE_USAGE = AdventureMessage.of("messages.freeze.usage", LANGUAGE_MANAGER);
+    public static final Message FREEZE_FROZEN = Message.of("messages.freeze.frozen");
+    public static final Message FREEZE_FROZEN_OTHER = Message.of("messages.freeze.frozen-other");
+    public static final Message FREEZE_UNFROZEN = Message.of("messages.freeze.unfrozen");
+    public static final Message FREEZE_UNFROZEN_OTHER = Message.of("messages.freeze.unfrozen-other");
+    public static final Message FREEZE_USAGE = Message.of("messages.freeze.usage");
 
-    public static final AdventureMessage VANISH_VANISHED = AdventureMessage.of("messages.vanish.vanished", LANGUAGE_MANAGER);
-    public static final AdventureMessage VANISH_VANISHED_OTHER = AdventureMessage.of("messages.vanish.vanished-other", LANGUAGE_MANAGER);
-    public static final AdventureMessage VANISH_UNVANISHED = AdventureMessage.of("messages.vanish.unvanished", LANGUAGE_MANAGER);
-    public static final AdventureMessage VANISH_UNVANISHED_OTHER = AdventureMessage.of("messages.vanish.unvanished-other", LANGUAGE_MANAGER);
-    public static final AdventureMessage VANISH_USAGE = AdventureMessage.of("messages.vanish.usage", LANGUAGE_MANAGER);
+    public static final Message VANISH_VANISHED = Message.of("messages.vanish.vanished");
+    public static final Message VANISH_VANISHED_OTHER = Message.of("messages.vanish.vanished-other");
+    public static final Message VANISH_UNVANISHED = Message.of("messages.vanish.unvanished");
+    public static final Message VANISH_UNVANISHED_OTHER = Message.of("messages.vanish.unvanished-other");
+    public static final Message VANISH_USAGE = Message.of("messages.vanish.usage");
 
-    public static final AdventureMessage HEAL_HEALED = AdventureMessage.of("messages.heal.healed", LANGUAGE_MANAGER);
-    public static final AdventureMessage HEAL_HEALED_OTHER = AdventureMessage.of("messages.heal.healed-other", LANGUAGE_MANAGER);
-    public static final AdventureMessage HEAL_USAGE = AdventureMessage.of("messages.heal.usage", LANGUAGE_MANAGER);
+    public static final Message HEAL_HEALED = Message.of("messages.heal.healed");
+    public static final Message HEAL_HEALED_OTHER = Message.of("messages.heal.healed-other");
+    public static final Message HEAL_USAGE = Message.of("messages.heal.usage");
 
-    public static final AdventureMessage FEED_FED = AdventureMessage.of("messages.feed.fed", LANGUAGE_MANAGER);
-    public static final AdventureMessage FEED_FED_OTHER = AdventureMessage.of("messages.feed.fed-other", LANGUAGE_MANAGER);
-    public static final AdventureMessage FEED_USAGE = AdventureMessage.of("messages.feed.usage", LANGUAGE_MANAGER);
+    public static final Message FEED_FED = Message.of("messages.feed.fed");
+    public static final Message FEED_FED_OTHER = Message.of("messages.feed.fed-other");
+    public static final Message FEED_USAGE = Message.of("messages.feed.usage");
 
-    public static final AdventureMessage REPAIR_REPAIRED = AdventureMessage.of("messages.repair.repaired", LANGUAGE_MANAGER);
-    public static final AdventureMessage REPAIR_REPAIRED_OTHER = AdventureMessage.of("messages.repair.repaired-other", LANGUAGE_MANAGER);
-    public static final AdventureMessage REPAIR_USAGE = AdventureMessage.of("messages.repair.usage", LANGUAGE_MANAGER);
-    public static final AdventureMessage REPAIR_NOT_REPAIRABLE = AdventureMessage.of("messages.repair.not-repairable", LANGUAGE_MANAGER);
-    public static final AdventureMessage REPAIR_NOT_REPAIRABLE_OTHER = AdventureMessage.of("messages.repair.not-repairable-other", LANGUAGE_MANAGER);
-    public static final AdventureMessage REPAIR_NO_ITEM = AdventureMessage.of("messages.repair.no-item", LANGUAGE_MANAGER);
-    public static final AdventureMessage REPAIR_NO_ITEM_OTHER = AdventureMessage.of("messages.repair.no-item-other", LANGUAGE_MANAGER);
+    public static final Message REPAIR_REPAIRED = Message.of("messages.repair.repaired");
+    public static final Message REPAIR_REPAIRED_OTHER = Message.of("messages.repair.repaired-other");
+    public static final Message REPAIR_USAGE = Message.of("messages.repair.usage");
+    public static final Message REPAIR_NOT_REPAIRABLE = Message.of("messages.repair.not-repairable");
+    public static final Message REPAIR_NOT_REPAIRABLE_OTHER = Message.of("messages.repair.not-repairable-other");
+    public static final Message REPAIR_NO_ITEM = Message.of("messages.repair.no-item");
+    public static final Message REPAIR_NO_ITEM_OTHER = Message.of("messages.repair.no-item-other");
 
-    public static final AdventureMessage INVENTORY_USAGE = AdventureMessage.of("messages.inventory.usage", LANGUAGE_MANAGER);
+    public static final Message INVENTORY_USAGE = Message.of("messages.inventory.usage");
 
-    public static final AdventureMessage ARMOR_USAGE = AdventureMessage.of("messages.armor.usage", LANGUAGE_MANAGER);
+    public static final Message ARMOR_USAGE = Message.of("messages.armor.usage");
 
-    public static final AdventureMessage SUN = AdventureMessage.of("messages.weather.sun", LANGUAGE_MANAGER);
-    public static final AdventureMessage RAIN = AdventureMessage.of("messages.weather.rain", LANGUAGE_MANAGER);
-    public static final AdventureMessage THUNDER = AdventureMessage.of("messages.weather.thunder", LANGUAGE_MANAGER);
-    public static final AdventureMessage WEATHER_USAGE = AdventureMessage.of("messages.weather.usage", LANGUAGE_MANAGER);
+    public static final Message SUN = Message.of("messages.weather.sun");
+    public static final Message RAIN = Message.of("messages.weather.rain");
+    public static final Message THUNDER = Message.of("messages.weather.thunder");
+    public static final Message WEATHER_USAGE = Message.of("messages.weather.usage");
 
-    public static final AdventureMessage MORNING = AdventureMessage.of("messages.time.morning", LANGUAGE_MANAGER);
-    public static final AdventureMessage DAY = AdventureMessage.of("messages.time.day", LANGUAGE_MANAGER);
-    public static final AdventureMessage MIDDAY = AdventureMessage.of("messages.time.midday", LANGUAGE_MANAGER);
-    public static final AdventureMessage EVENING = AdventureMessage.of("messages.time.evening", LANGUAGE_MANAGER);
-    public static final AdventureMessage NIGHT = AdventureMessage.of("messages.time.night", LANGUAGE_MANAGER);
-    public static final AdventureMessage TIME_USAGE = AdventureMessage.of("messages.time.usage", LANGUAGE_MANAGER);
+    public static final Message MORNING = Message.of("messages.time.morning");
+    public static final Message DAY = Message.of("messages.time.day");
+    public static final Message MIDDAY = Message.of("messages.time.midday");
+    public static final Message EVENING = Message.of("messages.time.evening");
+    public static final Message NIGHT = Message.of("messages.time.night");
+    public static final Message TIME_USAGE = Message.of("messages.time.usage");
 
-    public static final AdventureMessage CHATCLEAR_CLEARED = AdventureMessage.of("messages.chat.cleared", LANGUAGE_MANAGER);
+    public static final Message CHATCLEAR_CLEARED = Message.of("messages.chat.cleared");
 
-    public static final AdventureMessage SUICIDE = AdventureMessage.of("messages.suicide.killed", LANGUAGE_MANAGER);
+    public static final Message SUICIDE = Message.of("messages.suicide.killed");
 
-    public static final AdventureMessage TPA_OTHER_ONLY = AdventureMessage.of("messages.tpa.tpa.other-only", LANGUAGE_MANAGER);
+    public static final Message TPA_OTHER_ONLY = Message.of("messages.tpa.tpa.other-only");
 
-    public static final AdventureMessage TPA_LIST = AdventureMessage.of("messages.tpa.list.header", LANGUAGE_MANAGER);
-    public static final AdventureMessage TPA_LIST_NO_REQUEST = AdventureMessage.of("messages.tpa.list.no-request", LANGUAGE_MANAGER);
-    public static final AdventureMessage TPA_LIST_ENTRY = AdventureMessage.of("messages.tpa.list.entry", LANGUAGE_MANAGER);
+    public static final Message TPA_LIST = Message.of("messages.tpa.list.header");
+    public static final Message TPA_LIST_NO_REQUEST = Message.of("messages.tpa.list.no-request");
+    public static final Message TPA_LIST_ENTRY = Message.of("messages.tpa.list.entry");
 
-    public static final AdventureMessage TPA_REQUEST_SENT = AdventureMessage.of("messages.tpa.tpa.sent", LANGUAGE_MANAGER);
-    public static final AdventureMessage TPA_REQUEST_RECEIVED = AdventureMessage.of("messages.tpa.tpa.received", LANGUAGE_MANAGER);
-    public static final AdventureMessage TPA_REQUEST_ACCEPT = AdventureMessage.of("messages.tpa.tpa.accept", LANGUAGE_MANAGER);
-    public static final AdventureMessage TPA_REQUEST_DENY = AdventureMessage.of("messages.tpa.tpa.deny", LANGUAGE_MANAGER);
-    public static final AdventureMessage TPA_REQUEST_ACCEPT_HOVER = AdventureMessage.of("messages.tpa.tpa.accept-hover", LANGUAGE_MANAGER);
-    public static final AdventureMessage TPA_REQUEST_DENY_HOVER = AdventureMessage.of("messages.tpa.tpa.deny-hover", LANGUAGE_MANAGER);
-    public static final AdventureMessage TPA_REQUEST_ALREADY_SENT = AdventureMessage.of("messages.tpa.tpa.already-sent", LANGUAGE_MANAGER);
-    public static final AdventureMessage TPA_REQUEST_DENIED = AdventureMessage.of("messages.tpa.tpa.denied", LANGUAGE_MANAGER);
-    public static final AdventureMessage TPA_REQUEST_ACCEPTED = AdventureMessage.of("messages.tpa.tpa.accepted", LANGUAGE_MANAGER);
-    public static final AdventureMessage TPA_REQUEST_USAGE = AdventureMessage.of("messages.tpa.tpa.usage", LANGUAGE_MANAGER);
+    public static final Message TPA_REQUEST_SENT = Message.of("messages.tpa.tpa.sent");
+    public static final Message TPA_REQUEST_RECEIVED = Message.of("messages.tpa.tpa.received");
+    public static final Message TPA_REQUEST_ACCEPT = Message.of("messages.tpa.tpa.accept");
+    public static final Message TPA_REQUEST_DENY = Message.of("messages.tpa.tpa.deny");
+    public static final Message TPA_REQUEST_ACCEPT_HOVER = Message.of("messages.tpa.tpa.accept-hover");
+    public static final Message TPA_REQUEST_DENY_HOVER = Message.of("messages.tpa.tpa.deny-hover");
+    public static final Message TPA_REQUEST_ALREADY_SENT = Message.of("messages.tpa.tpa.already-sent");
+    public static final Message TPA_REQUEST_DENIED = Message.of("messages.tpa.tpa.denied");
+    public static final Message TPA_REQUEST_ACCEPTED = Message.of("messages.tpa.tpa.accepted");
+    public static final Message TPA_REQUEST_USAGE = Message.of("messages.tpa.tpa.usage");
 
-    public static final AdventureMessage TPA_TPACCEPT = AdventureMessage.of("messages.tpa.tpaccept.tpaccept", LANGUAGE_MANAGER);
-    public static final AdventureMessage TPA_TPACCEPT_USAGE = AdventureMessage.of("messages.tpa.tpaccept.usage", LANGUAGE_MANAGER);
+    public static final Message TPA_TPACCEPT = Message.of("messages.tpa.tpaccept.tpaccept");
+    public static final Message TPA_TPACCEPT_USAGE = Message.of("messages.tpa.tpaccept.usage");
 
-    public static final AdventureMessage TPA_TPDENY = AdventureMessage.of("messages.tpa.tpdeny.tpdeny", LANGUAGE_MANAGER);
-    public static final AdventureMessage TPA_TPDENY_USAGE = AdventureMessage.of("messages.tpa.tpdeny.usage", LANGUAGE_MANAGER);
+    public static final Message TPA_TPDENY = Message.of("messages.tpa.tpdeny.tpdeny");
+    public static final Message TPA_TPDENY_USAGE = Message.of("messages.tpa.tpdeny.usage");
 
-    public static final AdventureMessage DISCORD_CHAT_FORMAT = AdventureMessage.of("messages.discord.chat-format", LANGUAGE_MANAGER);
-    public static final AdventureMessage DISCORD_NO_PERMISSION = AdventureMessage.of("messages.discord.no-permission", LANGUAGE_MANAGER);
-    public static final AdventureMessage DISCORD_JOIN = AdventureMessage.of("messages.discord.join", LANGUAGE_MANAGER);
-    public static final AdventureMessage DISCORD_QUIT = AdventureMessage.of("messages.discord.quit", LANGUAGE_MANAGER);
-    public static final AdventureMessage DISCORD_STARTUP = AdventureMessage.of("messages.discord.startup", LANGUAGE_MANAGER);
-    public static final AdventureMessage DISCORD_SHUTDOWN = AdventureMessage.of("messages.discord.shutdown", LANGUAGE_MANAGER);
-    public static final AdventureMessage DISCORD_CLEARLAGG = AdventureMessage.of("messages.discord.clearlagg", LANGUAGE_MANAGER);
-    public static final AdventureMessage DISCORD_ONLINE_LIST = AdventureMessage.of("messages.discord.online.list", LANGUAGE_MANAGER);
-    public static final AdventureMessage DISCORD_NO_PLAYERS = AdventureMessage.of("messages.discord.online.no-players", LANGUAGE_MANAGER);
-    public static final AdventureMessage DISCORD_RESTART = AdventureMessage.of("messages.discord.restart.countdown", LANGUAGE_MANAGER);
-    public static final AdventureMessage DISCORD_RESTART_INSTANT = AdventureMessage.of("messages.discord.restart.instant", LANGUAGE_MANAGER);
-    public static final AdventureMessage DISCORD_CHAT_FORMAT_MINECRAFT = AdventureMessage.of("messages.discord.minecraft.chat-format", LANGUAGE_MANAGER);
-    public static final AdventureMessage DISCORD_RESTART_MINECRAFT = AdventureMessage.of("messages.discord.minecraft.restart.countdown", LANGUAGE_MANAGER);
-    public static final AdventureMessage DISCORD_WELCOME_MESSAGE = AdventureMessage.of("messages.discord.minecraft.welcome", LANGUAGE_MANAGER);
+    public static final Message DISCORD_CHAT_FORMAT = Message.of("messages.discord.chat-format");
+    public static final Message DISCORD_NO_PERMISSION = Message.of("messages.discord.no-permission");
+    public static final Message DISCORD_JOIN = Message.of("messages.discord.join");
+    public static final Message DISCORD_QUIT = Message.of("messages.discord.quit");
+    public static final Message DISCORD_STARTUP = Message.of("messages.discord.startup");
+    public static final Message DISCORD_SHUTDOWN = Message.of("messages.discord.shutdown");
+    public static final Message DISCORD_CLEARLAGG = Message.of("messages.discord.clearlagg");
+    public static final Message DISCORD_ONLINE_LIST = Message.of("messages.discord.online.list");
+    public static final Message DISCORD_NO_PLAYERS = Message.of("messages.discord.online.no-players");
+    public static final Message DISCORD_RESTART = Message.of("messages.discord.restart.countdown");
+    public static final Message DISCORD_RESTART_INSTANT = Message.of("messages.discord.restart.instant");
+    public static final Message DISCORD_CHAT_FORMAT_MINECRAFT = Message.of("messages.discord.minecraft.chat-format");
+    public static final Message DISCORD_RESTART_MINECRAFT = Message.of("messages.discord.minecraft.restart.countdown");
+    public static final Message DISCORD_WELCOME_MESSAGE = Message.of("messages.discord.minecraft.welcome");
 
-    public static final AdventureMessage HOME_SET_USAGE = AdventureMessage.of("messages.home.set.usage", LANGUAGE_MANAGER);
-    public static final AdventureMessage HOME_INVALID_NAME = AdventureMessage.of("messages.home.set.invalid-name", LANGUAGE_MANAGER);
-    public static final AdventureMessage HOME_MAX_HOMES_REACHED = AdventureMessage.of("messages.home.set.max", LANGUAGE_MANAGER);
-    public static final AdventureMessage HOME_ALREADY_EXISTS = AdventureMessage.of("messages.home.set.already-exists", LANGUAGE_MANAGER);
-    public static final AdventureMessage HOME_SET = AdventureMessage.of("messages.home.set.set", LANGUAGE_MANAGER);
+    public static final Message HOME_SET_USAGE = Message.of("messages.home.set.usage");
+    public static final Message HOME_INVALID_NAME = Message.of("messages.home.set.invalid-name");
+    public static final Message HOME_MAX_HOMES_REACHED = Message.of("messages.home.set.max");
+    public static final Message HOME_ALREADY_EXISTS = Message.of("messages.home.set.already-exists");
+    public static final Message HOME_SET = Message.of("messages.home.set.set");
 
-    public static final AdventureMessage HOME_LIST_HEADER = AdventureMessage.of("messages.home.list.header", LANGUAGE_MANAGER);
-    public static final AdventureMessage HOME_LIST_ENTRY = AdventureMessage.of("messages.home.list.entry", LANGUAGE_MANAGER);
-    public static final AdventureMessage HOME_LIST_HOVER = AdventureMessage.of("messages.home.list.hover", LANGUAGE_MANAGER);
-    public static final AdventureMessage HOME_NOT_FOUND = AdventureMessage.of("messages.home.not-found", LANGUAGE_MANAGER);
-    public static final AdventureMessage HOME_USAGE = AdventureMessage.of("messages.home.usage", LANGUAGE_MANAGER);
+    public static final Message HOME_LIST_HEADER = Message.of("messages.home.list.header");
+    public static final Message HOME_LIST_ENTRY = Message.of("messages.home.list.entry");
+    public static final Message HOME_LIST_HOVER = Message.of("messages.home.list.hover");
+    public static final Message HOME_NOT_FOUND = Message.of("messages.home.not-found");
+    public static final Message HOME_USAGE = Message.of("messages.home.usage");
 
-    public static final AdventureMessage HOME_DELETE_USAGE = AdventureMessage.of("messages.home.delete.usage", LANGUAGE_MANAGER);
-    public static final AdventureMessage HOME_DOES_NOT_EXIST = AdventureMessage.of("messages.home.delete.doesnt-exist", LANGUAGE_MANAGER);
-    public static final AdventureMessage HOME_DELETED = AdventureMessage.of("messages.home.delete.deleted", LANGUAGE_MANAGER);
+    public static final Message HOME_DELETE_USAGE = Message.of("messages.home.delete.usage");
+    public static final Message HOME_DOES_NOT_EXIST = Message.of("messages.home.delete.doesnt-exist");
+    public static final Message HOME_DELETED = Message.of("messages.home.delete.deleted");
 
-    public static final AdventureMessage WARP_SET_USAGE = AdventureMessage.of("messages.warp.set.usage", LANGUAGE_MANAGER);
-    public static final AdventureMessage WARP_INVALID_NAME = AdventureMessage.of("messages.warp.set.invalid-name", LANGUAGE_MANAGER);
-    public static final AdventureMessage WARP_ALREADY_EXISTS = AdventureMessage.of("messages.warp.set.already-exists", LANGUAGE_MANAGER);
-    public static final AdventureMessage WARP_SET = AdventureMessage.of("messages.warp.set.set", LANGUAGE_MANAGER);
+    public static final Message WARP_SET_USAGE = Message.of("messages.warp.set.usage");
+    public static final Message WARP_INVALID_NAME = Message.of("messages.warp.set.invalid-name");
+    public static final Message WARP_ALREADY_EXISTS = Message.of("messages.warp.set.already-exists");
+    public static final Message WARP_SET = Message.of("messages.warp.set.set");
 
-    public static final AdventureMessage WARP_LIST_HEADER = AdventureMessage.of("messages.warp.list.header", LANGUAGE_MANAGER);
-    public static final AdventureMessage WARP_LIST_ENTRY = AdventureMessage.of("messages.warp.list.entry", LANGUAGE_MANAGER);
-    public static final AdventureMessage WARP_LIST_HOVER = AdventureMessage.of("messages.warp.list.hover", LANGUAGE_MANAGER);
-    public static final AdventureMessage WARP_NOT_FOUND = AdventureMessage.of("messages.warp.not-found", LANGUAGE_MANAGER);
-    public static final AdventureMessage WARP_USAGE = AdventureMessage.of("messages.warp.usage", LANGUAGE_MANAGER);
+    public static final Message WARP_LIST_HEADER = Message.of("messages.warp.list.header");
+    public static final Message WARP_LIST_ENTRY = Message.of("messages.warp.list.entry");
+    public static final Message WARP_LIST_HOVER = Message.of("messages.warp.list.hover");
+    public static final Message WARP_NOT_FOUND = Message.of("messages.warp.not-found");
+    public static final Message WARP_USAGE = Message.of("messages.warp.usage");
 
-    public static final AdventureMessage WARP_DELETE_USAGE = AdventureMessage.of("messages.warp.delete.usage", LANGUAGE_MANAGER);
-    public static final AdventureMessage WARP_DOES_NOT_EXIST = AdventureMessage.of("messages.warp.delete.doesnt-exist", LANGUAGE_MANAGER);
-    public static final AdventureMessage WARP_DELETED = AdventureMessage.of("messages.warp.delete.deleted", LANGUAGE_MANAGER);
+    public static final Message WARP_DELETE_USAGE = Message.of("messages.warp.delete.usage");
+    public static final Message WARP_DOES_NOT_EXIST = Message.of("messages.warp.delete.doesnt-exist");
+    public static final Message WARP_DELETED = Message.of("messages.warp.delete.deleted");
 
-    public static final AdventureMessage RELOAD_SUCCESS = AdventureMessage.of("messages.reload.success", LANGUAGE_MANAGER);
-    public static final AdventureMessage RELOAD_FAIL = AdventureMessage.of("messages.reload.fail", LANGUAGE_MANAGER);
+    public static final Message RELOAD_SUCCESS = Message.of("messages.reload.success");
+    public static final Message RELOAD_FAIL = Message.of("messages.reload.fail");
 
-    public static final AdventureMessage MATERIAL = AdventureMessage.of("messages.material", LANGUAGE_MANAGER);
+    public static final Message MATERIAL = Message.of("messages.material");
 
-    public static final AdventureMessage ENCHANTINGTABLE_USAGE = AdventureMessage.of("messages.gui.enchantingtable.usage", LANGUAGE_MANAGER);
+    public static final Message ENCHANTINGTABLE_USAGE = Message.of("messages.gui.enchantingtable.usage");
 
     private static String getDefaultLocale() {
         return Locale.forLanguageTag(Configuration.DEFAULT_LANGUAGE.getValue()).toLanguageTag();
+    }
+
+    public static String get(String path) {
+        String[] parts = path.split("\\.");
+        Object current = LANGUAGE_DATA;
+        for (String part : parts) {
+            if (!(current instanceof Map)) return null;
+            current = ((Map<?, ?>) current).get(part);
+            if (current == null) return null;
+        }
+        return current.toString();
     }
 
     public static boolean load() {
         try {
             BukkitUtil.saveResource(Messages.class, "lang/de.json", LANGUAGE_PATH.resolve("de.json"));
             BukkitUtil.saveResource(Messages.class, "lang/en.json", LANGUAGE_PATH.resolve("en.json"));
-            loadFromFilesInDirectory(LANGUAGE_PATH.toFile());
-            return true;
-        } catch (IOException | URISyntaxException e) {
-            return false;
-        }
-
-    }
-
-    private static void loadFromFilesInDirectory(File directory) throws IOException, URISyntaxException {
-        if (!directory.isDirectory()) return;
-        for (File file : Objects.requireNonNull(LANGUAGE_PATH.toFile().listFiles())) {
-            if (file.isDirectory()) loadFromFilesInDirectory(file);
-            else if (file.getName().endsWith(".json"))
-                LANGUAGE_MANAGER.load(file.getName().replace(".json", ""), JacksonParser.createJsonParser(file));
-        }
-    }
-
-    public static boolean reload() {
-        try {
-            LANGUAGE_MANAGER.reload();
+            Path langFile = LANGUAGE_PATH.resolve(getDefaultLocale() + ".json");
+            if (Files.notExists(langFile)) {
+                langFile = LANGUAGE_PATH.resolve("en.json");
+            }
+            LANGUAGE_DATA = MAPPER.readValue(langFile.toFile(), Map.class);
             return true;
         } catch (IOException e) {
             return false;
         }
     }
 
+    public static boolean reload() {
+        return load();
+    }
 }

--- a/src/main/java/net/kettlemc/kessentials/discord/command/commands/ListSlashCommand.java
+++ b/src/main/java/net/kettlemc/kessentials/discord/command/commands/ListSlashCommand.java
@@ -1,6 +1,6 @@
 package net.kettlemc.kessentials.discord.command.commands;
 
-import io.github.almightysatan.slams.Placeholder;
+import net.kettlemc.kessentials.util.Placeholder;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
@@ -37,8 +37,8 @@ public class ListSlashCommand extends SlashCommand {
             int finalCount = count;
             event.reply(
                     LegacyComponentSerializer.legacySection().serialize(Messages.DISCORD_ONLINE_LIST.value(
-                            Placeholder.of("list", (ctx, value) -> playerList),
-                            Placeholder.of("amount", (ctx, args) -> String.valueOf(finalCount))
+                            Placeholder.of("list", () -> playerList),
+                            Placeholder.of("amount", () -> String.valueOf(finalCount))
                     ))
             ).queue();
         } else {

--- a/src/main/java/net/kettlemc/kessentials/discord/command/commands/StopServerCommand.java
+++ b/src/main/java/net/kettlemc/kessentials/discord/command/commands/StopServerCommand.java
@@ -1,6 +1,6 @@
 package net.kettlemc.kessentials.discord.command.commands;
 
-import io.github.almightysatan.slams.Placeholder;
+import net.kettlemc.kessentials.util.Placeholder;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
@@ -44,8 +44,8 @@ public class StopServerCommand extends SlashCommand {
             return;
         }
 
-        event.reply(LegacyComponentSerializer.legacySection().serialize(Messages.DISCORD_RESTART.value(Placeholder.of("seconds", (ctx, args) -> String.valueOf(seconds))))).queue();
-        Bukkit.getServer().broadcastMessage(LegacyComponentSerializer.legacySection().serialize(Messages.DISCORD_RESTART_MINECRAFT.value(Placeholder.of("seconds", (ctx, args) -> String.valueOf(seconds)))));
+        event.reply(LegacyComponentSerializer.legacySection().serialize(Messages.DISCORD_RESTART.value(Placeholder.of("seconds", () -> String.valueOf(seconds))))).queue();
+        Bukkit.getServer().broadcastMessage(LegacyComponentSerializer.legacySection().serialize(Messages.DISCORD_RESTART_MINECRAFT.value(Placeholder.of("seconds", () -> String.valueOf(seconds)))));
         Bukkit.getScheduler().runTaskLater(Essentials.instance().getPlugin(), () -> Bukkit.getServer().shutdown(), seconds * 20L);
     }
 

--- a/src/main/java/net/kettlemc/kessentials/discord/listener/MessageListener.java
+++ b/src/main/java/net/kettlemc/kessentials/discord/listener/MessageListener.java
@@ -1,6 +1,6 @@
 package net.kettlemc.kessentials.discord.listener;
 
-import io.github.almightysatan.slams.Placeholder;
+import net.kettlemc.kessentials.util.Placeholder;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.entities.channel.ChannelType;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
@@ -32,9 +32,9 @@ public class MessageListener extends ListenerAdapter {
 
         Essentials.instance().messages().broadcastMessage(Messages.DISCORD_CHAT_FORMAT_MINECRAFT,
                 false,
-                Placeholder.of("name", (ctx, value) -> event.getAuthor().getName()),
-                Placeholder.of("message", (ctx, value) -> event.getMessage().getContentDisplay()),
-                Placeholder.of("rank", (ctx, value) -> rank)
+                Placeholder.of("name", () -> event.getAuthor().getName()),
+                Placeholder.of("message", () -> event.getMessage().getContentDisplay()),
+                Placeholder.of("rank", () -> rank)
         );
     }
 

--- a/src/main/java/net/kettlemc/kessentials/discord/listener/bukkit/DiscordAsyncChatListener.java
+++ b/src/main/java/net/kettlemc/kessentials/discord/listener/bukkit/DiscordAsyncChatListener.java
@@ -1,6 +1,6 @@
 package net.kettlemc.kessentials.discord.listener.bukkit;
 
-import io.github.almightysatan.slams.Placeholder;
+import net.kettlemc.kessentials.util.Placeholder;
 import net.dv8tion.jda.api.utils.MarkdownSanitizer;
 import net.kettlemc.kessentials.util.BukkitUtil;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
@@ -34,9 +34,9 @@ public class DiscordAsyncChatListener implements Listener {
         // Format and send the message
         String finalPrefix = prefix;
         String message = LegacyComponentSerializer.legacySection().serialize(Messages.DISCORD_CHAT_FORMAT.value(
-                Placeholder.of("rank", (ctx, args) -> finalPrefix),
-                Placeholder.of("player", (ctx, args) -> name),
-                Placeholder.of("message", (ctx, args) -> chatMessage)
+                Placeholder.of("rank", () -> finalPrefix),
+                Placeholder.of("player", () -> name),
+                Placeholder.of("message", () -> chatMessage)
         ));
         Essentials.instance().getDiscordBot().sendMessage(message);
     }

--- a/src/main/java/net/kettlemc/kessentials/discord/listener/bukkit/DiscordClearLaggListener.java
+++ b/src/main/java/net/kettlemc/kessentials/discord/listener/bukkit/DiscordClearLaggListener.java
@@ -1,6 +1,6 @@
 package net.kettlemc.kessentials.discord.listener.bukkit;
 
-import io.github.almightysatan.slams.Placeholder;
+import net.kettlemc.kessentials.util.Placeholder;
 import me.minebuilders.clearlag.events.EntityRemoveEvent;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import net.kettlemc.kessentials.Essentials;
@@ -32,7 +32,7 @@ public class DiscordClearLaggListener implements Listener {
                 @Override
                 public void run() {
                     String message = LegacyComponentSerializer.legacySection().serialize(Messages.DISCORD_CLEARLAGG.value(
-                            Placeholder.of("items", (ctx, args) -> String.valueOf(lastCleared))
+                            Placeholder.of("items", () -> String.valueOf(lastCleared))
                     ));
                     Essentials.instance().getDiscordBot().sendMessage(message);
                     lastCleared = 0;

--- a/src/main/java/net/kettlemc/kessentials/discord/listener/bukkit/DiscordJoinQuitListener.java
+++ b/src/main/java/net/kettlemc/kessentials/discord/listener/bukkit/DiscordJoinQuitListener.java
@@ -1,6 +1,6 @@
 package net.kettlemc.kessentials.discord.listener.bukkit;
 
-import io.github.almightysatan.slams.Placeholder;
+import net.kettlemc.kessentials.util.Placeholder;
 import net.dv8tion.jda.api.utils.MarkdownSanitizer;
 import net.kettlemc.kessentials.util.BukkitUtil;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
@@ -19,11 +19,11 @@ public class DiscordJoinQuitListener implements Listener {
 
         String channel = BukkitUtil.stripEmojis(Essentials.instance().getDiscordBot().getMessageChannelById(DiscordConfiguration.DISCORD_CHANNEL_ID.getValue()).getName()).trim();
 
-        Essentials.instance().messages().sendMessage(event.getPlayer(), Messages.DISCORD_WELCOME_MESSAGE, Placeholder.of("channel", (ctx, args) -> channel));
+        Essentials.instance().messages().sendMessage(event.getPlayer(), Messages.DISCORD_WELCOME_MESSAGE, Placeholder.of("channel", () -> channel));
 
         String message = (DiscordConfiguration.DISCORD_DISABLE_FORMATTING.getValue() ? MarkdownSanitizer.escape(BukkitUtil.stripColor(event.getJoinMessage()), true) : BukkitUtil.stripColor(event.getJoinMessage()));
         if (message != null && !message.isEmpty()) {
-            Essentials.instance().getDiscordBot().sendMessage(LegacyComponentSerializer.legacySection().serialize(Messages.DISCORD_JOIN.value(Placeholder.of("message", (ctx, args) -> message))));
+            Essentials.instance().getDiscordBot().sendMessage(LegacyComponentSerializer.legacySection().serialize(Messages.DISCORD_JOIN.value(Placeholder.of("message", () -> message))));
         }
         Essentials.instance().getDiscordBot().updateStatusDelayed();
     }
@@ -32,7 +32,7 @@ public class DiscordJoinQuitListener implements Listener {
     public void onQuit(PlayerQuitEvent event) {
         String message = (DiscordConfiguration.DISCORD_DISABLE_FORMATTING.getValue() ? MarkdownSanitizer.escape(BukkitUtil.stripColor(event.getQuitMessage()), true) : BukkitUtil.stripColor(event.getQuitMessage()));
         if (message != null && !message.isEmpty()) {
-            Essentials.instance().getDiscordBot().sendMessage(LegacyComponentSerializer.legacySection().serialize(Messages.DISCORD_QUIT.value(Placeholder.of("message", (ctx, args) -> message))));
+            Essentials.instance().getDiscordBot().sendMessage(LegacyComponentSerializer.legacySection().serialize(Messages.DISCORD_QUIT.value(Placeholder.of("message", () -> message))));
         }
         Essentials.instance().getDiscordBot().updateStatusDelayed();
     }

--- a/src/main/java/net/kettlemc/kessentials/listener/JoinQuitListener.java
+++ b/src/main/java/net/kettlemc/kessentials/listener/JoinQuitListener.java
@@ -1,14 +1,13 @@
 package net.kettlemc.kessentials.listener;
 
-import io.github.almightysatan.slams.Placeholder;
+import net.kettlemc.kessentials.util.Placeholder;
+import net.kettlemc.kessentials.util.Message;
 import net.kettlemc.kessentials.Essentials;
 import net.kettlemc.kessentials.command.FreezeCommand;
 import net.kettlemc.kessentials.command.VanishCommand;
 import net.kettlemc.kessentials.config.Configuration;
 import net.kettlemc.kessentials.config.Messages;
-import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
-import org.bukkit.ChatColor;
+import net.kettlemc.kessentials.util.Util;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
@@ -24,8 +23,7 @@ public class JoinQuitListener implements Listener {
 
         Essentials.instance().homeHandler().loadHomes(event.getPlayer().getUniqueId());
 
-        Component component = Messages.JOIN_MESSAGE.value(Placeholder.of("player", (ctx, args) -> event.getPlayer().getName()));
-        event.setJoinMessage(ChatColor.translateAlternateColorCodes('&', LegacyComponentSerializer.legacyAmpersand().serialize(component)));
+        event.setJoinMessage(Util.translate(Messages.JOIN_MESSAGE, Placeholder.of("player", () -> event.getPlayer().getName())));
 
         // Hide vanished players from the player and disable the join message if the player is vanished
         hideVanished(event.getPlayer());
@@ -54,8 +52,7 @@ public class JoinQuitListener implements Listener {
 
     @EventHandler
     public void onQuit(PlayerQuitEvent event) {
-        Component component = Messages.QUIT_MESSAGE.value(Placeholder.of("player", (ctx, args) -> event.getPlayer().getName()));
-        event.setQuitMessage(ChatColor.translateAlternateColorCodes('&', LegacyComponentSerializer.legacyAmpersand().serialize(component)));
+        event.setQuitMessage(Util.translate(Messages.QUIT_MESSAGE, Placeholder.of("player", () -> event.getPlayer().getName())));
 
         // Disable the quit message if the player is vanished
         if (VanishCommand.isVanished(event.getPlayer())) {

--- a/src/main/java/net/kettlemc/kessentials/teleport/Teleportation.java
+++ b/src/main/java/net/kettlemc/kessentials/teleport/Teleportation.java
@@ -1,6 +1,6 @@
 package net.kettlemc.kessentials.teleport;
 
-import io.github.almightysatan.slams.Placeholder;
+import net.kettlemc.kessentials.util.Placeholder;
 import net.kettlemc.kessentials.Essentials;
 import net.kettlemc.kessentials.config.Messages;
 import org.bukkit.Location;
@@ -51,7 +51,7 @@ public class Teleportation {
 
     private static void startScheduler(Teleportation teleportation) {
 
-        Essentials.instance().messages().sendMessage(teleportation.getPlayer(), Messages.TELEPORTATION_COOLDOWN, Placeholder.of("cooldown", (ctx, args) -> String.valueOf(teleportation.cooldown)));
+        Essentials.instance().messages().sendMessage(teleportation.getPlayer(), Messages.TELEPORTATION_COOLDOWN, Placeholder.of("cooldown", () -> String.valueOf(teleportation.cooldown)));
 
         new BukkitRunnable() {
 

--- a/src/main/java/net/kettlemc/kessentials/util/Message.java
+++ b/src/main/java/net/kettlemc/kessentials/util/Message.java
@@ -1,0 +1,31 @@
+package net.kettlemc.kessentials.util;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import net.md_5.bungee.api.ChatColor;
+
+public class Message {
+    private final String path;
+
+    private Message(String path) {
+        this.path = path;
+    }
+
+    public static Message of(String path) {
+        return new Message(path);
+    }
+
+    public Component value(Placeholder... placeholders) {
+        String raw = Messages.get(path);
+        if (raw == null) {
+            raw = path;
+        }
+        if (placeholders != null) {
+            for (Placeholder p : placeholders) {
+                raw = raw.replace("<" + p.key() + ">", p.value());
+            }
+        }
+        raw = ChatColor.translateAlternateColorCodes('&', raw);
+        return LegacyComponentSerializer.legacySection().deserialize(raw);
+    }
+}

--- a/src/main/java/net/kettlemc/kessentials/util/MessageManager.java
+++ b/src/main/java/net/kettlemc/kessentials/util/MessageManager.java
@@ -1,7 +1,7 @@
 package net.kettlemc.kessentials.util;
 
-import io.github.almightysatan.slams.Placeholder;
-import io.github.almightysatan.slams.minimessage.AdventureMessage;
+import net.kettlemc.kessentials.util.Placeholder;
+import net.kettlemc.kessentials.util.Message;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.platform.bukkit.BukkitAudiences;
 import net.kyori.adventure.text.Component;
@@ -10,15 +10,15 @@ import org.bukkit.entity.Player;
 
 public class MessageManager {
 
-    private final AdventureMessage prefix;
+    private final Message prefix;
     private final BukkitAudiences adventure;
 
-    public MessageManager(AdventureMessage prefix, BukkitAudiences adventure) {
+    public MessageManager(Message prefix, BukkitAudiences adventure) {
         this.prefix = prefix;
         this.adventure = adventure;
     }
 
-    private Component build(boolean usePrefix, AdventureMessage message, Placeholder... placeholders) {
+    private Component build(boolean usePrefix, Message message, Placeholder... placeholders) {
         Component content = message.value(placeholders);
         if (usePrefix && prefix != null) {
             return prefix.value().append(Component.space()).append(content);
@@ -26,20 +26,20 @@ public class MessageManager {
         return content;
     }
 
-    public void sendMessage(CommandSender sender, AdventureMessage message, Placeholder... placeholders) {
+    public void sendMessage(CommandSender sender, Message message, Placeholder... placeholders) {
         sendMessage(sender, true, message, placeholders);
     }
 
-    public void sendMessage(CommandSender sender, boolean prefix, AdventureMessage message, Placeholder... placeholders) {
+    public void sendMessage(CommandSender sender, boolean prefix, Message message, Placeholder... placeholders) {
         Audience audience = (sender instanceof Player) ? adventure.player((Player) sender) : adventure.sender(sender);
         audience.sendMessage(build(prefix, message, placeholders));
     }
 
-    public void broadcastMessage(AdventureMessage message, Placeholder... placeholders) {
+    public void broadcastMessage(Message message, Placeholder... placeholders) {
         broadcastMessage(message, true, placeholders);
     }
 
-    public void broadcastMessage(AdventureMessage message, boolean prefix, Placeholder... placeholders) {
+    public void broadcastMessage(Message message, boolean prefix, Placeholder... placeholders) {
         adventure.all().sendMessage(build(prefix, message, placeholders));
     }
 }

--- a/src/main/java/net/kettlemc/kessentials/util/Placeholder.java
+++ b/src/main/java/net/kettlemc/kessentials/util/Placeholder.java
@@ -1,0 +1,25 @@
+package net.kettlemc.kessentials.util;
+
+import java.util.function.Supplier;
+
+public class Placeholder {
+    private final String key;
+    private final Supplier<String> supplier;
+
+    private Placeholder(String key, Supplier<String> supplier) {
+        this.key = key;
+        this.supplier = supplier;
+    }
+
+    public static Placeholder of(String key, Supplier<String> supplier) {
+        return new Placeholder(key, supplier);
+    }
+
+    public String key() {
+        return key;
+    }
+
+    public String value() {
+        return supplier.get();
+    }
+}

--- a/src/main/java/net/kettlemc/kessentials/util/RestartTimer.java
+++ b/src/main/java/net/kettlemc/kessentials/util/RestartTimer.java
@@ -1,6 +1,6 @@
 package net.kettlemc.kessentials.util;
 
-import io.github.almightysatan.slams.Placeholder;
+import net.kettlemc.kessentials.util.Placeholder;
 import net.kettlemc.kessentials.Essentials;
 import net.kettlemc.kessentials.config.Configuration;
 import net.kettlemc.kessentials.config.Messages;
@@ -39,7 +39,7 @@ public class RestartTimer {
                 Essentials.instance().getPlugin().getLogger().info("Scheduled restart warning " + timeWarning + " ticks before restart.");
                 long warningDelay = delay - timeWarning;
                 Bukkit.getScheduler().runTaskLaterAsynchronously(Essentials.instance().getPlugin(), () -> {
-                    Placeholder timeValue = Placeholder.of("time", (ctx, args) -> timeMessage(warningDelay * 20));
+                    Placeholder timeValue = Placeholder.of("time", () -> timeMessage(warningDelay * 20));
                     Essentials.instance().messages().broadcastMessage(Messages.RESTART, timeValue);
                 }, warningDelay);
             }

--- a/src/main/java/net/kettlemc/kessentials/util/Util.java
+++ b/src/main/java/net/kettlemc/kessentials/util/Util.java
@@ -1,7 +1,7 @@
 package net.kettlemc.kessentials.util;
 
-import io.github.almightysatan.slams.Placeholder;
-import io.github.almightysatan.slams.minimessage.AdventureMessage;
+import net.kettlemc.kessentials.util.Placeholder;
+import net.kettlemc.kessentials.util.Message;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.Bukkit;
 
@@ -15,14 +15,6 @@ public class Util {
         return Bukkit.getPluginManager().getPlugin("LuckPerms") != null;
     }
 
-    public static boolean miniMessagesAvailable() {
-        try {
-            Class.forName("net.kyori.adventure.text.minimessage.MiniMessage");
-            return true;
-        } catch (ClassNotFoundException e) {
-            return false;
-        }
-    }
 
     /**
      * Parse a time string in the format of "HH:mm" to a LocalTime object
@@ -41,7 +33,7 @@ public class Util {
     }
 
 
-    public static String translate(AdventureMessage message, Placeholder... placeholders) {
+    public static String translate(Message message, Placeholder... placeholders) {
         return LegacyComponentSerializer.legacySection().serialize(message.value(placeholders));
     }
 


### PR DESCRIPTION
## Summary
- switch SLAMS implementation to legacy
- drop minimessage dependencies
- implement simple Message/Placeholder utilities
- adapt message handling to use legacy color codes

## Testing
- `./gradlew build -x test` *(fails: Unable to tunnel through proxy)*
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68448eaf2818833184aecc9012401edf