### PR TITLE
Use JDA 4 for Discord support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ The plugin allows for easy moderation of players and the server, as well as a fe
 4. Run `./gradlew build` to build the plugin
 5. Install the plugin on your server and restart it
 
-6. Run the server on **JDK 8 or newer**. Discord features rely on JDA 5 and therefore need **JDK 11+** at runtime
+6. Run the server on **JDK 8 or newer**. Discord features use JDA 4 and also run on Java 8.
 
-> **Build vs. Runtime JDK**: Use JDK 17+ to run Gradle, but the compiled plugin works on Java 8 servers. Only the optional Discord integration requires Java 11 or newer at runtime.
+> **Build vs. Runtime JDK**: Use JDK 17+ to run Gradle, but the compiled plugin works on Java 8 servers. When no Discord token is set the bot is disabled and Discord-related commands won't function.
 
 ## 🧾 Commands
 ```

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -6,7 +6,7 @@ dependencies {
 
     internal "net.kyori:adventure-api:4.14.0"
     internal "net.kyori:adventure-platform-bukkit:4.3.0"
-    implementation "net.dv8tion:JDA:5.0.0-beta.24"
+    implementation "net.dv8tion:JDA:4.4.0_352"
     implementation "net.luckperms:api:5.3"
     implementation "org.xerial:sqlite-jdbc:3.36.0.3"
 }

--- a/src/main/java/net/kettlemc/kessentials/discord/DiscordBot.java
+++ b/src/main/java/net/kettlemc/kessentials/discord/DiscordBot.java
@@ -5,7 +5,7 @@ import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.JDABuilder;
 import net.dv8tion.jda.api.OnlineStatus;
 import net.dv8tion.jda.api.entities.Activity;
-import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
+import net.dv8tion.jda.api.entities.MessageChannel;
 import net.dv8tion.jda.api.requests.GatewayIntent;
 import net.dv8tion.jda.api.requests.restaction.CommandListUpdateAction;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;

--- a/src/main/java/net/kettlemc/kessentials/discord/command/SlashCommand.java
+++ b/src/main/java/net/kettlemc/kessentials/discord/command/SlashCommand.java
@@ -1,8 +1,8 @@
 package net.kettlemc.kessentials.discord.command;
 
 import net.dv8tion.jda.api.entities.Member;
-import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
-import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.entities.MessageChannel;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandEvent;
 import net.dv8tion.jda.api.requests.restaction.CommandListUpdateAction;
 import net.kettlemc.kessentials.Essentials;
 
@@ -18,7 +18,7 @@ public abstract class SlashCommand {
         this.name = name;
     }
 
-    public abstract void onExecute(SlashCommandInteractionEvent event, Member member, MessageChannel channel);
+    public abstract void onExecute(SlashCommandEvent event, Member member, MessageChannel channel);
 
     public abstract void construct(CommandListUpdateAction commands);
 

--- a/src/main/java/net/kettlemc/kessentials/discord/command/SlashCommandListener.java
+++ b/src/main/java/net/kettlemc/kessentials/discord/command/SlashCommandListener.java
@@ -1,20 +1,20 @@
 package net.kettlemc.kessentials.discord.command;
 
-import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import net.kettlemc.kessentials.config.DiscordConfiguration;
 
 public class SlashCommandListener extends ListenerAdapter {
 
     @Override
-    public void onSlashCommandInteraction(SlashCommandInteractionEvent event) {
+    public void onSlashCommand(SlashCommandEvent event) {
         String commandName = event.getName();
 
         SlashCommand command;
 
         if ((command = SlashCommand.commandMap.get(commandName)) != null) {
             if (DiscordConfiguration.DISCORD_ALLOW_EVERY_CHANNEL_FOR_COMMANDS.getValue() || event.getChannel().getIdLong() == DiscordConfiguration.DISCORD_CHANNEL_ID.getValue()) {
-                command.onExecute(event, event.getMember(), event.getMessageChannel());
+                command.onExecute(event, event.getMember(), event.getChannel());
             }
         }
     }

--- a/src/main/java/net/kettlemc/kessentials/discord/command/commands/AdminInfoSlashCommand.java
+++ b/src/main/java/net/kettlemc/kessentials/discord/command/commands/AdminInfoSlashCommand.java
@@ -2,8 +2,8 @@ package net.kettlemc.kessentials.discord.command.commands;
 
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Member;
-import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
-import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.entities.MessageChannel;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
@@ -26,7 +26,7 @@ public class AdminInfoSlashCommand extends SlashCommand {
     }
 
     @Override
-    public void onExecute(SlashCommandInteractionEvent event, Member member, MessageChannel channel) {
+    public void onExecute(SlashCommandEvent event, Member member, MessageChannel channel) {
         if (!member.hasPermission(Permission.ADMINISTRATOR)) {
             event.reply("You do not have permission to use this command.").setEphemeral(true).queue();
             return;

--- a/src/main/java/net/kettlemc/kessentials/discord/command/commands/ListSlashCommand.java
+++ b/src/main/java/net/kettlemc/kessentials/discord/command/commands/ListSlashCommand.java
@@ -2,8 +2,8 @@ package net.kettlemc.kessentials.discord.command.commands;
 
 import net.kettlemc.kessentials.util.Placeholder;
 import net.dv8tion.jda.api.entities.Member;
-import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
-import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.entities.MessageChannel;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandEvent;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
 import net.dv8tion.jda.api.requests.restaction.CommandListUpdateAction;
 import net.dv8tion.jda.api.utils.MarkdownSanitizer;
@@ -21,7 +21,7 @@ public class ListSlashCommand extends SlashCommand {
     }
 
     @Override
-    public void onExecute(SlashCommandInteractionEvent event, Member member, MessageChannel channel) {
+    public void onExecute(SlashCommandEvent event, Member member, MessageChannel channel) {
         int count = 0;
         StringBuilder players = new StringBuilder();
 

--- a/src/main/java/net/kettlemc/kessentials/discord/command/commands/PlayerInfoSlashCommand.java
+++ b/src/main/java/net/kettlemc/kessentials/discord/command/commands/PlayerInfoSlashCommand.java
@@ -1,8 +1,8 @@
 package net.kettlemc.kessentials.discord.command.commands;
 
 import net.dv8tion.jda.api.entities.Member;
-import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
-import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.entities.MessageChannel;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
@@ -24,7 +24,7 @@ public class PlayerInfoSlashCommand extends SlashCommand {
     }
 
     @Override
-    public void onExecute(SlashCommandInteractionEvent event, Member member, MessageChannel channel) {
+    public void onExecute(SlashCommandEvent event, Member member, MessageChannel channel) {
         OptionMapping nameOption = event.getOption("name");
         String name = nameOption != null ? nameOption.getAsString() : null;
         if (name == null || name.isEmpty()) {

--- a/src/main/java/net/kettlemc/kessentials/discord/command/commands/PositionSlashCommand.java
+++ b/src/main/java/net/kettlemc/kessentials/discord/command/commands/PositionSlashCommand.java
@@ -2,8 +2,8 @@ package net.kettlemc.kessentials.discord.command.commands;
 
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Member;
-import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
-import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.entities.MessageChannel;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
@@ -23,7 +23,7 @@ public class PositionSlashCommand extends SlashCommand {
     }
 
     @Override
-    public void onExecute(SlashCommandInteractionEvent event, Member member, MessageChannel channel) {
+    public void onExecute(SlashCommandEvent event, Member member, MessageChannel channel) {
         if (!member.hasPermission(Permission.ADMINISTRATOR)) {
             event.reply("You do not have permission to use this command.").setEphemeral(true).queue();
             return;

--- a/src/main/java/net/kettlemc/kessentials/discord/command/commands/StopServerCommand.java
+++ b/src/main/java/net/kettlemc/kessentials/discord/command/commands/StopServerCommand.java
@@ -3,8 +3,8 @@ package net.kettlemc.kessentials.discord.command.commands;
 import net.kettlemc.kessentials.util.Placeholder;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Member;
-import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
-import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.entities.MessageChannel;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.CommandData;
@@ -24,7 +24,7 @@ public class StopServerCommand extends SlashCommand {
     }
 
     @Override
-    public void onExecute(SlashCommandInteractionEvent event, Member member, MessageChannel channel) {
+    public void onExecute(SlashCommandEvent event, Member member, MessageChannel channel) {
         if (!member.hasPermission(Permission.ADMINISTRATOR)) {
             event.reply(LegacyComponentSerializer.legacySection().serialize(Messages.DISCORD_NO_PERMISSION.value())).queue();
             return;

--- a/src/main/java/net/kettlemc/kessentials/discord/command/commands/TeamInfoSlashCommand.java
+++ b/src/main/java/net/kettlemc/kessentials/discord/command/commands/TeamInfoSlashCommand.java
@@ -1,8 +1,8 @@
 package net.kettlemc.kessentials.discord.command.commands;
 
 import net.dv8tion.jda.api.entities.Member;
-import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
-import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.entities.MessageChannel;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
@@ -27,7 +27,7 @@ public class TeamInfoSlashCommand extends SlashCommand {
     }
 
     @Override
-    public void onExecute(SlashCommandInteractionEvent event, Member member, MessageChannel channel) {
+    public void onExecute(SlashCommandEvent event, Member member, MessageChannel channel) {
         OptionMapping nameOption = event.getOption("name");
         String name = nameOption != null ? nameOption.getAsString() : null;
         if (name == null || name.isEmpty()) {

--- a/src/main/java/net/kettlemc/kessentials/discord/command/commands/TopKillsSlashCommand.java
+++ b/src/main/java/net/kettlemc/kessentials/discord/command/commands/TopKillsSlashCommand.java
@@ -1,8 +1,8 @@
 package net.kettlemc.kessentials.discord.command.commands;
 
 import net.dv8tion.jda.api.entities.Member;
-import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
-import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.entities.MessageChannel;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandEvent;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
 import net.dv8tion.jda.api.requests.restaction.CommandListUpdateAction;
 import net.kettlemc.kessentials.Essentials;
@@ -25,7 +25,7 @@ public class TopKillsSlashCommand extends SlashCommand {
     }
 
     @Override
-    public void onExecute(SlashCommandInteractionEvent event, Member member, MessageChannel channel) {
+    public void onExecute(SlashCommandEvent event, Member member, MessageChannel channel) {
         PlayerDataDAO dao = Essentials.instance().playerDataDAO();
         try {
             List<Map.Entry<UUID, Integer>> list = dao.getTopKills(5);

--- a/src/main/java/net/kettlemc/kessentials/discord/command/commands/TopTeamsSlashCommand.java
+++ b/src/main/java/net/kettlemc/kessentials/discord/command/commands/TopTeamsSlashCommand.java
@@ -1,8 +1,8 @@
 package net.kettlemc.kessentials.discord.command.commands;
 
 import net.dv8tion.jda.api.entities.Member;
-import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
-import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.entities.MessageChannel;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandEvent;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
 import net.dv8tion.jda.api.requests.restaction.CommandListUpdateAction;
 import net.kettlemc.kessentials.Essentials;
@@ -23,7 +23,7 @@ public class TopTeamsSlashCommand extends SlashCommand {
     }
 
     @Override
-    public void onExecute(SlashCommandInteractionEvent event, Member member, MessageChannel channel) {
+    public void onExecute(SlashCommandEvent event, Member member, MessageChannel channel) {
         ClanDAO dao = Essentials.instance().clanDAO();
         try {
             List<Map.Entry<String, Integer>> list = dao.getTopClans(5);

--- a/src/main/java/net/kettlemc/kessentials/discord/command/commands/VerifySlashCommand.java
+++ b/src/main/java/net/kettlemc/kessentials/discord/command/commands/VerifySlashCommand.java
@@ -1,8 +1,8 @@
 package net.kettlemc.kessentials.discord.command.commands;
 
 import net.dv8tion.jda.api.entities.Member;
-import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
-import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.entities.MessageChannel;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
@@ -24,7 +24,7 @@ public class VerifySlashCommand extends SlashCommand {
     }
 
     @Override
-    public void onExecute(SlashCommandInteractionEvent event, Member member, MessageChannel channel) {
+    public void onExecute(SlashCommandEvent event, Member member, MessageChannel channel) {
         OptionMapping codeOption = event.getOption("code");
         String code = codeOption != null ? codeOption.getAsString() : null;
         if (code == null || code.isEmpty()) {


### PR DESCRIPTION
## Summary
- downgrade JDA to 4.4.0_352
- update Discord classes for JDA 4 APIs
- clarify Java 8 runtime requirement and note that Discord features are disabled when no token is set

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68449167d71483319ef98b0ef0b110b8