### PR TITLE
Update armorsee inventory sync

### DIFF
--- a/src/main/java/net/kettlemc/kessentials/Essentials.java
+++ b/src/main/java/net/kettlemc/kessentials/Essentials.java
@@ -151,6 +151,7 @@ public final class Essentials implements Loadable {
         this.contentManager.registerListener(new BlockListener());
         this.contentManager.registerListener(new PlayerMoveListener());
         this.contentManager.registerListener(new InventoryClickListener());
+        this.contentManager.registerListener(new ArmorChangeListener());
         this.contentManager.registerListener(new CommandListener());
         this.contentManager.registerListener(new EnchantingTableListener());
 

--- a/src/main/java/net/kettlemc/kessentials/command/ArmorSeeCommand.java
+++ b/src/main/java/net/kettlemc/kessentials/command/ArmorSeeCommand.java
@@ -53,11 +53,33 @@ public class ArmorSeeCommand implements CommandExecutor, TabCompleter {
         inventory.setItem(1, target.getInventory().getChestplate());
         inventory.setItem(2, target.getInventory().getLeggings());
         inventory.setItem(3, target.getInventory().getBoots());
-        inventory.setItem(4, new ItemStack(Material.AIR)); // TODO: Offhand
+        inventory.setItem(4, target.getInventory().getItemInOffHand());
 
         ((Player) sender).openInventory(inventory);
 
         return true;
+    }
+
+    /**
+     * Refreshes all open armor inventories of the given player.
+     *
+     * @param player The player whose armor should be displayed
+     */
+    public static void refreshArmorInventories(Player player) {
+        for (Player viewer : Bukkit.getOnlinePlayers()) {
+            Inventory open = viewer.getOpenInventory().getTopInventory();
+            if (open.getHolder() instanceof ArmorInventoryHolder) {
+                ArmorInventoryHolder holder = (ArmorInventoryHolder) open.getHolder();
+                if (holder.player().equals(player)) {
+                    open.setItem(0, player.getInventory().getHelmet());
+                    open.setItem(1, player.getInventory().getChestplate());
+                    open.setItem(2, player.getInventory().getLeggings());
+                    open.setItem(3, player.getInventory().getBoots());
+                    open.setItem(4, player.getInventory().getItemInOffHand());
+                    viewer.updateInventory();
+                }
+            }
+        }
     }
 
     @Override

--- a/src/main/java/net/kettlemc/kessentials/listener/ArmorChangeListener.java
+++ b/src/main/java/net/kettlemc/kessentials/listener/ArmorChangeListener.java
@@ -1,0 +1,29 @@
+package net.kettlemc.kessentials.listener;
+
+import net.kettlemc.kessentials.command.ArmorSeeCommand;
+import net.kettlemc.kessentials.Essentials;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerItemBreakEvent;
+import org.bukkit.event.player.PlayerSwapHandItemsEvent;
+
+/**
+ * Updates opened armorsee inventories when the player's armor changes outside of inventory clicks.
+ */
+public class ArmorChangeListener implements Listener {
+
+    @EventHandler
+    public void onSwapHand(PlayerSwapHandItemsEvent event) {
+        Bukkit.getScheduler().runTask(Essentials.instance().getPlugin(), () ->
+                ArmorSeeCommand.refreshArmorInventories(event.getPlayer()));
+    }
+
+    @EventHandler
+    public void onItemBreak(PlayerItemBreakEvent event) {
+        Player player = event.getPlayer();
+        Bukkit.getScheduler().runTask(Essentials.instance().getPlugin(), () ->
+                ArmorSeeCommand.refreshArmorInventories(player));
+    }
+}

--- a/src/main/java/net/kettlemc/kessentials/listener/InventoryClickListener.java
+++ b/src/main/java/net/kettlemc/kessentials/listener/InventoryClickListener.java
@@ -1,9 +1,13 @@
 package net.kettlemc.kessentials.listener;
 
 import net.kettlemc.kessentials.command.ArmorSeeCommand;
+import net.kettlemc.kessentials.Essentials;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.Bukkit;
 
 public class InventoryClickListener implements Listener {
 
@@ -15,10 +19,24 @@ public class InventoryClickListener implements Listener {
         }
 
         if (event.getClickedInventory().getHolder() instanceof ArmorSeeCommand.ArmorInventoryHolder) {
-            ArmorSeeCommand.ArmorInventoryHolder holder = (ArmorSeeCommand.ArmorInventoryHolder) event.getClickedInventory().getHolder();
             event.setCancelled(true);
-            // TODO: Update the open armor inventories if a player updates their armor
+            return;
+        }
 
+        if (!(event.getWhoClicked() instanceof Player)) {
+            return;
+        }
+
+        Player player = (Player) event.getWhoClicked();
+
+        // Check if the player clicked an armor or offhand slot in their own inventory
+        if (event.getClickedInventory().getHolder() instanceof Player
+                && ((Player) event.getClickedInventory().getHolder()).equals(player)) {
+
+            if (event.getSlotType() == InventoryType.SlotType.ARMOR || event.getSlot() == 40) {
+                Bukkit.getScheduler().runTask(Essentials.instance().getPlugin(), () ->
+                        ArmorSeeCommand.refreshArmorInventories(player));
+            }
         }
 
     }


### PR DESCRIPTION
## Summary
- refresh ArmorSee hopper with off-hand item
- update open ArmorSee inventories when armor/off-hand slots change
- listen for off-hand swaps and broken armor pieces

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684492bded3c8331bfe4d520dc8fa4d0