### PR TITLE
Remove deprecated PaperMC repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,10 +40,6 @@ javadoc { options.encoding = "UTF-8" }
 repositories {
     mavenCentral()
     maven {
-        name = "papermc-legacy"
-        url = "https://papermc.io/repo/repository/maven-public/"
-    }
-    maven {
         name = "papermc"
         url = "https://repo.papermc.io/repository/maven-public/"
     }


### PR DESCRIPTION
## Summary
- drop `papermc-legacy` repository since it points to an obsolete URL

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6844983cfe048331b6350be5e086214c