### PR TITLE
Improve logging for database and config errors

### DIFF
--- a/src/main/java/net/kettlemc/kessentials/config/Configuration.java
+++ b/src/main/java/net/kettlemc/kessentials/config/Configuration.java
@@ -10,6 +10,7 @@ import io.github.almightysatan.jaskl.hocon.HoconConfig;
 import net.kettlemc.kessentials.Essentials;
 
 import java.io.IOException;
+import java.util.logging.Level;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
@@ -70,7 +71,7 @@ public class Configuration {
             return true;
         } catch (IOException e) {
             Essentials.instance().getPlugin().getLogger().severe("Failed to load configuration: " + e.getMessage());
-            e.printStackTrace();
+            Essentials.instance().getPlugin().getLogger().log(Level.SEVERE, "Failed to load configuration", e);
             return false;
         }
     }

--- a/src/main/java/net/kettlemc/kessentials/listener/KillListener.java
+++ b/src/main/java/net/kettlemc/kessentials/listener/KillListener.java
@@ -9,6 +9,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.entity.PlayerDeathEvent;
 
 import java.sql.SQLException;
+import java.util.logging.Level;
 
 /**
  * Captures kill events, updates the database and notifies Discord.
@@ -33,7 +34,7 @@ public class KillListener implements Listener {
                 dao.incrementKills(killer.getUniqueId());
             }
         } catch (SQLException e) {
-            e.printStackTrace();
+            Essentials.instance().getPlugin().getLogger().log(Level.SEVERE, "Failed to update kill statistics", e);
         }
 
         scoreboardHandler.updateScoreboard(victim);

--- a/src/main/java/net/kettlemc/kessentials/util/ScoreboardHandler.java
+++ b/src/main/java/net/kettlemc/kessentials/util/ScoreboardHandler.java
@@ -2,6 +2,7 @@ package net.kettlemc.kessentials.util;
 
 import net.kettlemc.kessentials.data.PlayerDataDAO;
 import net.kettlemc.kessentials.data.ClanDAO;
+import net.kettlemc.kessentials.Essentials;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
@@ -15,6 +16,7 @@ import org.bukkit.scoreboard.Scoreboard;
 import org.bukkit.scoreboard.ScoreboardManager;
 
 import java.sql.SQLException;
+import java.util.logging.Level;
 
 /**
  * Simple scoreboard handler to display kills and deaths for each player.
@@ -57,7 +59,7 @@ public class ScoreboardHandler implements Listener {
 
             player.setScoreboard(board);
         } catch (SQLException e) {
-            e.printStackTrace();
+            Essentials.instance().getPlugin().getLogger().log(Level.SEVERE, "Failed to update scoreboard for " + player.getName(), e);
         }
     }
 }


### PR DESCRIPTION
## Summary
- switch from `printStackTrace()` to logging exceptions using the plugin logger
- log Level.SEVERE on failures in `Configuration`, `ScoreboardHandler`, and `KillListener`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68449af93c448331ad9c72252689a9bd